### PR TITLE
Added handling of Meta node

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/JSONAPISpecConstants.java
+++ b/src/main/java/com/github/jasminb/jsonapi/JSONAPISpecConstants.java
@@ -15,4 +15,5 @@ public interface JSONAPISpecConstants {
 	String LINKS = "links";
 	String SELF = "self";
 	String ERRORS = "errors";
+	String META = "meta";
 }

--- a/src/main/java/com/github/jasminb/jsonapi/ReflectionUtils.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ReflectionUtils.java
@@ -49,11 +49,11 @@ public class ReflectionUtils {
 		return typeAnnotation != null ? typeAnnotation.value() : null;
 	}
 
-	public static Class<?> getRelationshipType(Field relationshipField) {
-		Class<?> targetType = relationshipField.getType();
+	public static Class<?> getFieldType(Field field) {
+		Class<?> targetType = field.getType();
 
 		if (targetType.equals(List.class)) {
-			ParameterizedType stringListType = (ParameterizedType) relationshipField.getGenericType();
+			ParameterizedType stringListType = (ParameterizedType) field.getGenericType();
 			targetType = (Class<?>) stringListType.getActualTypeArguments()[0];
 		}
 

--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -453,9 +453,14 @@ public class ResourceConverter {
 		// Perform initial conversion
 		ObjectNode attributesNode = objectMapper.valueToTree(object);
 
-		// Remove id and relationship fields
+		// Remove id, meta and relationship fields
 		Field idField = ID_MAP.get(object.getClass());
 		attributesNode.remove(idField.getName());
+
+		Field metaField = META_FIELD.get(object.getClass());
+		if (metaField!=null) {
+			attributesNode.remove(metaField.getName());
+		}
 
 		// Handle resource identifier
 		ObjectNode dataNode = objectMapper.createObjectNode();

--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -86,10 +86,10 @@ public class ResourceConverter {
 
 				// collecting Meta fields
 				List<Field> metaFields = ReflectionUtils.getAnnotatedFields(clazz, Meta.class);
-				if (metaFields.size()>1) {
+				if (metaFields.size() > 1) {
 					throw new IllegalArgumentException(String.format("Only one meta field is allowed for type '%s'", clazz.getCanonicalName()));
 				}
-				if (metaFields.size()==1) {
+				if (metaFields.size() == 1) {
 					Field metaField = metaFields.get(0);
 					metaField.setAccessible(true);
 					Class<?> metaType = ReflectionUtils.getFieldType(metaField);
@@ -163,7 +163,7 @@ public class ResourceConverter {
 			// handling of meta node
 			if (rootNode.has(META)) {
 				Field field = META_FIELD.get(clazz);
-				if (field!=null) {
+				if (field != null) {
 					Class<?> metaType = META_TYPE_MAP.get(clazz);
 					Object metaObject = objectMapper.treeToValue(rootNode.get(META), metaType);
 					field.set(result, metaObject);

--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.jasminb.jsonapi.annotations.Meta;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
@@ -34,6 +35,8 @@ public class ResourceConverter {
 	private static final Map<Class<?>, List<Field>> RELATIONSHIPS_MAP = new HashMap<>();
 	private static final Map<Class<?>, Map<String, Class<?>>> RELATIONSHIP_TYPE_MAP = new HashMap<>();
 	private static final Map<Class<?>, Map<String, Field>> RELATIONSHIP_FIELD_MAP = new HashMap<>();
+	private static final Map<Class<?>, Class<?>> META_TYPE_MAP = new HashMap<>();
+	private static final Map<Class<?>, Field> META_FIELD = new HashMap<>();
 
 
 	private ObjectMapper objectMapper;
@@ -54,13 +57,14 @@ public class ResourceConverter {
 				RELATIONSHIP_TYPE_MAP.put(clazz, new HashMap<String, Class<?>>());
 				RELATIONSHIP_FIELD_MAP.put(clazz, new HashMap<String, Field>());
 
+				// collecting Relationship fields
 				List<Field> relationshipFields = ReflectionUtils.getAnnotatedFields(clazz, Relationship.class);
 
 				for (Field relationshipField : relationshipFields) {
 					relationshipField.setAccessible(true);
 
 					Relationship relationship = relationshipField.getAnnotation(Relationship.class);
-					Class<?> targetType = ReflectionUtils.getRelationshipType(relationshipField);
+					Class<?> targetType = ReflectionUtils.getFieldType(relationshipField);
 					RELATIONSHIP_TYPE_MAP.get(clazz).put(relationship.value(), targetType);
 					RELATIONSHIP_FIELD_MAP.get(clazz).put(relationship.value(), relationshipField);
 
@@ -68,6 +72,7 @@ public class ResourceConverter {
 
 				RELATIONSHIPS_MAP.put(clazz, relationshipFields);
 
+				// collecting Id fields
 				List<Field> idAnnotatedFields = ReflectionUtils.getAnnotatedFields(clazz, Id.class);
 
 				if (!idAnnotatedFields.isEmpty()) {
@@ -77,6 +82,19 @@ public class ResourceConverter {
 				} else {
 					throw new IllegalArgumentException("All resource classes must have a field annotated with the " +
 							"@Id annotation");
+				}
+
+				// collecting Meta fields
+				List<Field> metaFields = ReflectionUtils.getAnnotatedFields(clazz, Meta.class);
+				if (metaFields.size()>1) {
+					throw new IllegalArgumentException(String.format("Only one meta field is allowed for type '%s'", clazz.getCanonicalName()));
+				}
+				if (metaFields.size()==1) {
+					Field metaField = metaFields.get(0);
+					metaField.setAccessible(true);
+					Class<?> metaType = ReflectionUtils.getFieldType(metaField);
+					META_TYPE_MAP.put(clazz, metaType);
+					META_FIELD.put(clazz, metaField);
 				}
 			} else {
 				throw new IllegalArgumentException("All resource classes must be annotated with Type annotation!");
@@ -141,6 +159,16 @@ public class ResourceConverter {
 			JsonNode dataNode = rootNode.get(DATA);
 
 			T result = readObject(dataNode, clazz, included);
+
+			// handling of meta node
+			if (rootNode.has(META)) {
+				Field field = META_FIELD.get(clazz);
+				if (field!=null) {
+					Class<?> metaType = META_TYPE_MAP.get(clazz);
+					Object metaObject = objectMapper.treeToValue(rootNode.get(META), metaType);
+					field.set(result, metaObject);
+				}
+			}
 
 			return result;
 		} catch (RuntimeException e) {

--- a/src/main/java/com/github/jasminb/jsonapi/annotations/Meta.java
+++ b/src/main/java/com/github/jasminb/jsonapi/annotations/Meta.java
@@ -1,0 +1,17 @@
+package com.github.jasminb.jsonapi.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used to configure relationship field in JSON API resources.
+ *
+ * @author jbegic
+ */
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Meta {
+}

--- a/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
@@ -83,6 +83,26 @@ public class ResourceConverterTest {
 	}
 
 	@Test
+	public void testWriteWithMetaSection() throws IOException, IllegalAccessException {
+		User initialUser = new User();
+		User.UserMeta userMeta = new User.UserMeta();
+		userMeta.token = "test";
+		initialUser = new User();
+		initialUser.meta = userMeta;
+		initialUser.id = "123";
+		initialUser.name = "John Nash";
+
+		byte [] rawData = converter.writeObject(initialUser);
+
+		Assert.assertNotNull(rawData);
+		Assert.assertFalse(rawData.length == 0);
+
+		User converted = converter.readObject(rawData, User.class);
+
+		Assert.assertEquals(null, converted.getMeta());
+	}
+
+	@Test
 	public void testResolverGlobal() throws IOException {
 		converter.setGlobalResolver(new RelationshipResolver() {
 			@Override

--- a/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
@@ -73,6 +73,16 @@ public class ResourceConverterTest {
 	}
 
 	@Test
+	public void testReadWithMetaSection() throws IOException {
+		String apiResponse = IOUtils.getResourceAsString("user-with-meta.json");
+
+		User user = converter.readObject(apiResponse.getBytes(), User.class);
+
+		Assert.assertNotNull(user.getMeta());
+		Assert.assertEquals("asdASD123", user.getMeta().getToken());
+	}
+
+	@Test
 	public void testResolverGlobal() throws IOException {
 		converter.setGlobalResolver(new RelationshipResolver() {
 			@Override

--- a/src/test/java/com/github/jasminb/jsonapi/models/User.java
+++ b/src/test/java/com/github/jasminb/jsonapi/models/User.java
@@ -1,6 +1,7 @@
 package com.github.jasminb.jsonapi.models;
 
 import com.github.jasminb.jsonapi.annotations.Id;
+import com.github.jasminb.jsonapi.annotations.Meta;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
 
@@ -9,6 +10,14 @@ import java.util.List;
 @Type("users")
 public class User {
 
+	public static class UserMeta {
+		private String token;
+
+		public String getToken() {
+			return token;
+		}
+	}
+
 	@Id
 	private String id;
 	private String name;
@@ -16,6 +25,8 @@ public class User {
 	@Relationship("statuses")
 	private List<Status> statuses;
 
+	@Meta
+	private UserMeta meta;
 
 	public String getId() {
 		return id;
@@ -39,5 +50,9 @@ public class User {
 
 	public void setStatuses(List<Status> statuses) {
 		this.statuses = statuses;
+	}
+
+	public UserMeta getMeta() {
+		return meta;
 	}
 }

--- a/src/test/java/com/github/jasminb/jsonapi/models/User.java
+++ b/src/test/java/com/github/jasminb/jsonapi/models/User.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class User {
 
 	public static class UserMeta {
-		private String token;
+		public String token;
 
 		public String getToken() {
 			return token;
@@ -19,14 +19,14 @@ public class User {
 	}
 
 	@Id
-	private String id;
-	private String name;
+	public String id;
+	public String name;
 
 	@Relationship("statuses")
 	private List<Status> statuses;
 
 	@Meta
-	private UserMeta meta;
+	public UserMeta meta;
 
 	public String getId() {
 		return id;
@@ -55,4 +55,5 @@ public class User {
 	public UserMeta getMeta() {
 		return meta;
 	}
+
 }

--- a/src/test/resources/user-with-meta.json
+++ b/src/test/resources/user-with-meta.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "type": "users",
+    "id": "userId",
+    "attributes": {
+      "name": "liz"
+    }
+  },
+  "meta": {
+    "token" : "asdASD123"
+  }
+}


### PR DESCRIPTION
I implemented it the same way relationships are handled. That is to say : 
- if meta node is found in json but @meta node is present, ignore and don't throw error
- if @meta node is present but meta node in json is not present, ignore and don't throw error

however, I think it would be good to manage those situations in the future, in order to avoid debugging nightmares