### PR TITLE
Demonstrates a recursion bug, and proposed fix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.5</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<distributionManagement>

--- a/src/main/java/com/github/jasminb/jsonapi/ResolverState.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResolverState.java
@@ -1,0 +1,79 @@
+package com.github.jasminb.jsonapi;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents the state that must be maintained when recursively resolving relationships for a given {@code Field}.  The
+ * implementation that resolves relationships will maintain this state for each {@link Field} being resolved.
+ */
+class ResolverState {
+
+    /**
+     * The relationship type being resolved (e.g. "self", "related")
+     */
+    private final String relType;
+
+    /**
+     * The Java Field for which relationships are being resolved
+     */
+    private final Field field;
+
+    /**
+     * Maintains a set of urls that have been visited when resolving relationships
+     */
+    private final Set<String> visited = new HashSet<>();
+
+    /**
+     * Constructs a new state object.
+     *
+     * @param field the Java {@code Field} for which relationships are being resolved
+     * @param relType the relationship type being navigated (e.g. "self", "related") for this {@code field}
+     */
+    ResolverState(Field field, String relType) {
+        if (relType == null || relType.trim().equals("")) {
+            throw new IllegalArgumentException("Missing relationship type.");
+        }
+
+        if (field == null) {
+            throw new IllegalArgumentException("Cannot manage state for a null Field.");
+        }
+
+        this.relType = relType;
+        this.field = field;
+    }
+
+    /**
+     * Used by the relationship resolution implementation to record that a URL has been visited for the purpose of
+     * resolving a relationship.  Useful for detecting recursive loops.  Typically the {@code url} will be
+     * the value of a "self" or "related" link.  If a link has been visited previously, this method will return
+     * {@code true}.
+     *
+     * @param url a link url
+     * @return true if {@code url} has already been visited, {@code false} otherwise
+     */
+    boolean visited(String url) {
+        return !this.visited.add(url);
+    }
+
+    /**
+     * Used by the relationship resolution implementation to maintain the relationship type being resolved for this
+     * {@code {@link #getField() field}.  Typically "related" or "self".
+     *
+     * @return the relationship type being resolved
+     */
+    String getRelType() {
+        return relType;
+    }
+
+    /**
+     * Used by the relationship resolution implementation to maintain the {@code Field} being resolved.
+     *
+     * @return the {@code Field} being resolved
+     */
+    Field getField() {
+        return field;
+    }
+
+}

--- a/src/test/java/com/github/jasminb/jsonapi/models/recursion/RecursingNode.java
+++ b/src/test/java/com/github/jasminb/jsonapi/models/recursion/RecursingNode.java
@@ -1,0 +1,56 @@
+package com.github.jasminb.jsonapi.models.recursion;
+
+import com.github.jasminb.jsonapi.RelType;
+import com.github.jasminb.jsonapi.annotations.Id;
+import com.github.jasminb.jsonapi.annotations.Relationship;
+import com.github.jasminb.jsonapi.annotations.Type;
+
+/**
+ * A test class that has a parent.
+ */
+@Type("node")
+public class RecursingNode {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    private String url;
+
+    @Relationship(value = "parent", resolve = true, relType = RelType.RELATED)
+    private RecursingNode parent;
+
+    public RecursingNode getParent() {
+        return parent;
+    }
+
+    public void setParent(RecursingNode parent) {
+        this.parent = parent;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/src/test/resources/com/github/jasminb/jsonapi/models/recursion/loop.json
+++ b/src/test/resources/com/github/jasminb/jsonapi/models/recursion/loop.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "relationships": {
+      "parent": {
+        "links": {
+          "related": {
+            "href": "http://example.com/node/1"
+          }
+        }
+      }
+    },
+    "attributes": {
+      "name": "parent",
+      "url": "http://example.com/node/1"
+    },
+    "type": "node",
+    "id": "1"
+  }
+}


### PR DESCRIPTION
Hi,

So I ran into a bug with recursion (#28), and put together this PR for your comment.  I tried to implement a solution that was the least invasive, but it turns out not to be very pretty.

A new class named `ResolverState` is used to track which URLs are visited when resolving relationships.  `ResolverState` is created on a field basis.  That is, for each (@Relationship-annotated) `Field` in an object, `ResourceConverter` will create a new `ResolverState`.  The `ResourceConverter` has been updated to carry the `ResolverState` through the method call hierarchy.  Because the method call hierarchy is a little complex, I maintained the public signatures of `readObject(...)` and `readObjectCollection(...)` but renamed the private versions to `readObjectInternal(...)` and updated them to accept/carry the `ResolverState`.

`ResolverState` could be used in the future to help maintain additional state.  For example, it could carry a `depth` property which could be used by the modeler to control how many levels of recursion are performed.  Additionally, perhaps, the `Map` of included resources could be carried on it as well.