### PR TITLE
Upgrade to Retrofit 2.1.0 from 2.0.0-beta2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.squareup.retrofit</groupId>
+			<groupId>com.squareup.retrofit2</groupId>
 			<artifactId>retrofit</artifactId>
-			<version>2.0.0-beta2</version>
+			<version>2.1.0</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/github/jasminb/jsonapi/ErrorUtils.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ErrorUtils.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jasminb.jsonapi.models.errors.ErrorResponse;
-import com.squareup.okhttp.ResponseBody;
+import okhttp3.ResponseBody;
 
 import java.io.IOException;
 

--- a/src/main/java/com/github/jasminb/jsonapi/retrofit/JSONAPIConverterFactory.java
+++ b/src/main/java/com/github/jasminb/jsonapi/retrofit/JSONAPIConverterFactory.java
@@ -2,9 +2,10 @@ package com.github.jasminb.jsonapi.retrofit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jasminb.jsonapi.ResourceConverter;
-import com.squareup.okhttp.RequestBody;
-import com.squareup.okhttp.ResponseBody;
-import retrofit.Converter;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -37,8 +38,10 @@ public class JSONAPIConverterFactory extends Converter.Factory {
 		this.alternativeFactory = alternativeFactory;
 	}
 
+
+
 	@Override
-	public Converter<ResponseBody, ?> fromResponseBody(Type type, Annotation[] annotations) {
+	public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
 		RetrofitType retrofitType = new RetrofitType(type);
 
 		if (retrofitType.isValid() && parser.isRegisteredType(retrofitType.getType())) {
@@ -48,20 +51,20 @@ public class JSONAPIConverterFactory extends Converter.Factory {
 				return new JSONAPIResponseBodyConverter<>(parser, retrofitType.getType(), false);
 			}
 		} else if (alternativeFactory != null) {
-			return alternativeFactory.fromResponseBody(type, annotations);
+			return alternativeFactory.responseBodyConverter(type, annotations, retrofit);
 		} else {
 			return null;
 		}
 	}
 
 	@Override
-	public Converter<?, RequestBody> toRequestBody(Type type, Annotation[] annotations) {
+	public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
 		RetrofitType retrofitType = new RetrofitType(type);
 
 		if (retrofitType.isValid() && parser.isRegisteredType(retrofitType.getType())) {
 			return new JSONAPIRequestBodyConverter<>(parser);
 		} else if (alternativeFactory != null) {
-			return alternativeFactory.toRequestBody(type, annotations);
+			return alternativeFactory.requestBodyConverter(type, parameterAnnotations, methodAnnotations, retrofit);
 		} else {
 			return null;
 		}

--- a/src/main/java/com/github/jasminb/jsonapi/retrofit/JSONAPIRequestBodyConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/retrofit/JSONAPIRequestBodyConverter.java
@@ -1,9 +1,9 @@
 package com.github.jasminb.jsonapi.retrofit;
 
 import com.github.jasminb.jsonapi.ResourceConverter;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.RequestBody;
-import retrofit.Converter;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import retrofit2.Converter;
 
 import java.io.IOException;
 

--- a/src/main/java/com/github/jasminb/jsonapi/retrofit/JSONAPIResponseBodyConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/retrofit/JSONAPIResponseBodyConverter.java
@@ -1,8 +1,8 @@
 package com.github.jasminb.jsonapi.retrofit;
 
 import com.github.jasminb.jsonapi.ResourceConverter;
-import com.squareup.okhttp.ResponseBody;
-import retrofit.Converter;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
 
 import java.io.IOException;
 

--- a/src/test/java/com/github/jasminb/jsonapi/retrofit/RetrofitTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/retrofit/RetrofitTest.java
@@ -13,8 +13,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import retrofit.Response;
-import retrofit.Retrofit;
+import retrofit2.Response;
+import retrofit2.Retrofit;
 
 import java.io.IOException;
 import java.util.List;
@@ -62,7 +62,7 @@ public class RetrofitTest {
 
 		Response<User> response = service.getExampleResource().execute();
 
-		Assert.assertTrue(response.isSuccess());
+		Assert.assertTrue(response.isSuccessful());
 
 		User user = response.body();
 
@@ -80,7 +80,7 @@ public class RetrofitTest {
 
 		Response<List<User>> response = service.getExampleResourceList().execute();
 
-		Assert.assertTrue(response.isSuccess());
+		Assert.assertTrue(response.isSuccessful());
 
 		List<User> users = response.body();
 		Assert.assertEquals(2, users.size());
@@ -96,7 +96,7 @@ public class RetrofitTest {
 
 		Response<User> response = service.getExampleResource().execute();
 
-		Assert.assertFalse(response.isSuccess());
+		Assert.assertFalse(response.isSuccessful());
 
 		ErrorResponse errorResponse = ErrorUtils.parseErrorResponse(response.errorBody());
 

--- a/src/test/java/com/github/jasminb/jsonapi/retrofit/SimpleService.java
+++ b/src/test/java/com/github/jasminb/jsonapi/retrofit/SimpleService.java
@@ -2,10 +2,10 @@ package com.github.jasminb.jsonapi.retrofit;
 
 import com.github.jasminb.jsonapi.models.User;
 import com.github.jasminb.jsonapi.models.errors.ErrorResponse;
-import retrofit.Call;
-import retrofit.http.Body;
-import retrofit.http.GET;
-import retrofit.http.POST;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
 
 import java.util.List;
 


### PR DESCRIPTION
This is a backward-incompatible change.

- [breaking] JSONAPIConverterFactory public method signatures change to align with updated Retrofit2 Converter.Factory interface
- [breaking] Re-packaging of `retrofit.*` classes to `retrofit2.*` include method signature changes
- Upgrade to OkHttp version 3.2.0 from 2.5.0