### PR TITLE
fixes and refactoring, refactor and fix some tests also

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/ErrorUtils.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ErrorUtils.java
@@ -1,13 +1,14 @@
 package com.github.jasminb.jsonapi;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.jasminb.jsonapi.models.errors.ErrorResponse;
-import okhttp3.ResponseBody;
+import com.github.jasminb.jsonapi.models.errors.Errors;
 
 import java.io.IOException;
+import java.io.InputStream;
+
+import okhttp3.ResponseBody;
 
 /**
  * Utility class providing methods needed for parsing JSON API Spec errors.
@@ -15,34 +16,37 @@ import java.io.IOException;
  * @author jbegic
  */
 public class ErrorUtils {
-	private static final ObjectMapper MAPPER = new ObjectMapper();
 
-	static {
-		MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-	}
+    private ErrorUtils() {
+        // Private constructor
+    }
 
-	private ErrorUtils() {
-		// Private constructor
-	}
+    /**
+     * Parses provided ResponseBody and returns it as T.
+     *
+     * @param mapper        Jackson Object mapper instance
+     * @param errorResponse error response body
+     * @return T collection
+     * @throws IOException
+     */
+    public static <T extends Errors> T parseErrorResponse(ObjectMapper mapper, ResponseBody errorResponse, Class<T> cls) throws IOException {
+        return mapper.readValue(errorResponse.bytes(), cls);
+    }
 
-	/**
-	 * Parses provided ResponseBody and returns it as ErrorResponse.
-	 * @param errorResponse error response body
-	 * @return ErrorResponse collection
-	 * @throws IOException
-	 */
-	public static ErrorResponse parseErrorResponse(ResponseBody errorResponse) throws IOException {
-		return MAPPER.readValue(errorResponse.bytes(), ErrorResponse.class);
-	}
+    /**
+     * Parses provided JsonNode and returns it as T.
+     *
+     * @param mapper        Jackson Object mapper instance
+     * @param errorResponse error response body
+     * @return T collection
+     * @throws JsonProcessingException thrown in case JsonNode cannot be parsed
+     */
+    public static <T extends Errors> T parseError(ObjectMapper mapper, JsonNode errorResponse, Class<T> cls) throws JsonProcessingException {
+        return mapper.treeToValue(errorResponse, cls);
+    }
 
-	/**
-	 * Parses provided JsonNode and returns it as ErrorResponse.
-	 * @param errorResponse error response body
-	 * @return ErrorResponse collection
-	 * @throws JsonProcessingException thrown in case JsonNode cannot be parsed
-	 */
-	public static ErrorResponse parseError(JsonNode errorResponse) throws JsonProcessingException {
-		return MAPPER.treeToValue(errorResponse, ErrorResponse.class);
-	}
+    public static <T extends Errors> T parseError(ObjectMapper mapper, InputStream errorResponse, Class<T> cls) throws IOException {
+        return mapper.readValue(errorResponse, cls);
+    }
 
 }

--- a/src/main/java/com/github/jasminb/jsonapi/ValidationUtils.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ValidationUtils.java
@@ -2,7 +2,9 @@ package com.github.jasminb.jsonapi;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jasminb.jsonapi.exceptions.ResourceParseException;
+import com.github.jasminb.jsonapi.models.errors.Errors;
 
 /**
  * Utility methods for validating segments of JSON API resource object.
@@ -51,10 +53,10 @@ public class ValidationUtils {
 	 * @param resourceNode resource node
 	 * @throws ResourceParseException
 	 */
-	public static void ensureNotError(JsonNode resourceNode) {
+	public static void ensureNotError(ObjectMapper mapper, JsonNode resourceNode) {
 		if (resourceNode != null && resourceNode.hasNonNull(JSONAPISpecConstants.ERRORS)) {
 			try {
-				throw new ResourceParseException(ErrorUtils.parseError(resourceNode));
+				throw new ResourceParseException(ErrorUtils.parseError(mapper, resourceNode, Errors.class));
 			} catch (JsonProcessingException e) {
 				throw new RuntimeException(e);
 			}

--- a/src/main/java/com/github/jasminb/jsonapi/exceptions/ResourceParseException.java
+++ b/src/main/java/com/github/jasminb/jsonapi/exceptions/ResourceParseException.java
@@ -1,6 +1,6 @@
 package com.github.jasminb.jsonapi.exceptions;
 
-import com.github.jasminb.jsonapi.models.errors.ErrorResponse;
+import com.github.jasminb.jsonapi.models.errors.Errors;
 
 /**
  * ResourceParseException implementation. <br />
@@ -9,18 +9,18 @@ import com.github.jasminb.jsonapi.models.errors.ErrorResponse;
  * @author jbegic
  */
 public class ResourceParseException extends RuntimeException {
-	private final ErrorResponse errorResponse;
+	private final Errors errors;
 
-	public ResourceParseException(ErrorResponse errorResponse) {
-		super(errorResponse.toString());
-		this.errorResponse = errorResponse;
+	public ResourceParseException(Errors errors) {
+		super(errors.toString());
+		this.errors = errors;
 	}
 
 	/**
-	 * Returns ErrorResponse or <code>null</code>
-	 * @return {@link ErrorResponse}
+	 * Returns Errors or <code>null</code>
+	 * @return {@link Errors}
 	 */
-	public ErrorResponse getErrorResponse() {
-		return errorResponse;
+	public Errors getErrors() {
+		return errors;
 	}
 }

--- a/src/main/java/com/github/jasminb/jsonapi/models/errors/Errors.java
+++ b/src/main/java/com/github/jasminb/jsonapi/models/errors/Errors.java
@@ -7,7 +7,7 @@ import java.util.List;
  *
  * @author jbegic
  */
-public class ErrorResponse {
+public class Errors {
 	private List<Error> errors;
 
 	public List<Error> getErrors() {
@@ -20,7 +20,7 @@ public class ErrorResponse {
 
 	@Override
 	public String toString() {
-		return "ErrorResponse{" +
+		return "Errors{" +
 				"errors=" + (errors != null ? errors : "Undefined") +
 				'}';
 	}

--- a/src/main/java/com/github/jasminb/jsonapi/retrofit/JSONAPIDocumentResponseBodyConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/retrofit/JSONAPIDocumentResponseBodyConverter.java
@@ -1,0 +1,35 @@
+package com.github.jasminb.jsonapi.retrofit;
+
+import com.github.jasminb.jsonapi.JSONAPIDocument;
+import com.github.jasminb.jsonapi.ResourceConverter;
+
+import java.io.IOException;
+
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+
+/**
+ * JSON API response body converter.
+ *
+ * @author jbegic
+ */
+public class JSONAPIDocumentResponseBodyConverter<T> implements Converter<ResponseBody, JSONAPIDocument<T>> {
+	private final Class<?> clazz;
+	private final Boolean isCollection;
+	private final ResourceConverter parser;
+
+	public JSONAPIDocumentResponseBodyConverter(ResourceConverter parser, Class<?> clazz, boolean isCollection) {
+		this.clazz = clazz;
+		this.isCollection = isCollection;
+		this.parser = parser;
+	}
+
+	@Override
+	public JSONAPIDocument<T> convert(ResponseBody responseBody) throws IOException {
+		if (isCollection) {
+			return (JSONAPIDocument<T>) parser.readDocumentCollection(responseBody.byteStream(), clazz);
+		} else {
+			return (JSONAPIDocument<T>) parser.readDocument(responseBody.byteStream(), clazz);
+		}
+	}
+}

--- a/src/main/java/com/github/jasminb/jsonapi/retrofit/JSONAPIRequestBodyConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/retrofit/JSONAPIRequestBodyConverter.java
@@ -1,11 +1,12 @@
 package com.github.jasminb.jsonapi.retrofit;
 
 import com.github.jasminb.jsonapi.ResourceConverter;
+
+import java.io.IOException;
+
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import retrofit2.Converter;
-
-import java.io.IOException;
 
 /**
  * JSON API request body converter implementation.

--- a/src/main/java/com/github/jasminb/jsonapi/retrofit/JSONAPIResponseBodyConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/retrofit/JSONAPIResponseBodyConverter.java
@@ -1,10 +1,11 @@
 package com.github.jasminb.jsonapi.retrofit;
 
 import com.github.jasminb.jsonapi.ResourceConverter;
-import okhttp3.ResponseBody;
-import retrofit2.Converter;
 
 import java.io.IOException;
+
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
 
 /**
  * JSON API response body converter.
@@ -25,9 +26,9 @@ public class JSONAPIResponseBodyConverter<T> implements Converter<ResponseBody, 
 	@Override
 	public T convert(ResponseBody responseBody) throws IOException {
 		if (isCollection) {
-			return (T) parser.readDocumentCollection(responseBody.bytes(), clazz).get();
+			return (T) parser.readDocumentCollection(responseBody.byteStream(), clazz).get();
 		} else {
-			return (T) parser.readDocument(responseBody.bytes(), clazz).get();
+			return (T) parser.readDocument(responseBody.byteStream(), clazz).get();
 		}
 	}
 }

--- a/src/main/java/com/github/jasminb/jsonapi/retrofit/RetrofitType.java
+++ b/src/main/java/com/github/jasminb/jsonapi/retrofit/RetrofitType.java
@@ -1,5 +1,7 @@
 package com.github.jasminb.jsonapi.retrofit;
 
+import com.github.jasminb.jsonapi.JSONAPIDocument;
+
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
@@ -7,55 +9,70 @@ import java.lang.reflect.Type;
  * Simple class used to simplify type management in Retrofit converter factory.
  */
 public class RetrofitType {
-	private Class<?> type;
-	private boolean collection;
-	private boolean valid = true;
+    private Class<?> type;
 
-	/**
-	 * Instantiates a new Retrofit type.
-	 *
-	 * @param type the type
-	 */
-	public RetrofitType(Type type) {
-		if (type instanceof ParameterizedType) {
-			Type[] typeArgs = ((ParameterizedType) type).getActualTypeArguments();
-			if (typeArgs != null && typeArgs.length > 0) {
-				this.type = (Class<?>) typeArgs[0];
-				this.collection = true;
-			} else {
-				valid = false;
-			}
-		} else if (type instanceof Class) {
-			this.type = (Class<?>) type;
-		} else {
-			valid = false;
-		}
-	}
+    private boolean collection;
+    private boolean valid = true;
+    private boolean isParentType = false;
 
-	/**
-	 * Gets type.
-	 *
-	 * @return the type
-	 */
-	public Class<?> getType() {
-		return type;
-	}
+    /**
+     * Instantiates a new Retrofit type.
+     *
+     * @param type the type
+     */
+    public RetrofitType(Type type) {
+        if (type instanceof ParameterizedType && ((ParameterizedType) type).getRawType().equals(JSONAPIDocument.class)) {
+            initialize(((ParameterizedType) type).getActualTypeArguments()[0]);
+            isParentType = true;
+        } else {
+            initialize(type);
+        }
+    }
 
-	/**
-	 * Is collection boolean.
-	 *
-	 * @return <code>true</code> if type was ParameterizedType else <code>false</code>
-	 */
-	public boolean isCollection() {
-		return collection;
-	}
+    private void initialize(Type type) {
+        if (type instanceof ParameterizedType) {
+            Type[] typeArgs = ((ParameterizedType) type).getActualTypeArguments();
+            if (typeArgs != null && typeArgs.length > 0) {
+                this.type = (Class<?>) typeArgs[0];
+                this.collection = true;
+            } else {
+                valid = false;
+            }
+        } else if (type instanceof Class) {
+            this.type = (Class<?>) type;
+        } else {
+            valid = false;
+        }
+    }
 
-	/**
-	 * Is valid boolean.
-	 *
-	 * @return <code>true</code> if type is valid, else <code>false</code>
-	 */
-	public boolean isValid() {
-		return valid;
-	}
+    public boolean isJSONAPIDocumentType() {
+        return isParentType;
+    }
+
+    /**
+     * Gets type.
+     *
+     * @return the type
+     */
+    public Class<?> getType() {
+        return type;
+    }
+
+    /**
+     * Is collection boolean.
+     *
+     * @return <code>true</code> if type was ParameterizedType else <code>false</code>
+     */
+    public boolean isCollection() {
+        return collection;
+    }
+
+    /**
+     * Is valid boolean.
+     *
+     * @return <code>true</code> if type is valid, else <code>false</code>
+     */
+    public boolean isValid() {
+        return valid;
+    }
 }

--- a/src/test/java/com/github/jasminb/jsonapi/IOUtils.java
+++ b/src/test/java/com/github/jasminb/jsonapi/IOUtils.java
@@ -25,4 +25,8 @@ public class IOUtils {
 			return resultBuilder.toString();
 		}
 	}
+	public static InputStream getResource(String name) throws IOException {
+		InputStream input = IOUtils.class.getClassLoader().getResourceAsStream(name);
+		return input;
+	}
 }

--- a/src/test/java/com/github/jasminb/jsonapi/InheritedAnnotationsTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/InheritedAnnotationsTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -25,9 +26,11 @@ public class InheritedAnnotationsTest {
 
 	@Test
 	public void testConversion() throws IOException {
-		String data = IOUtils.getResourceAsString("engineer.json");
+		InputStream data = IOUtils.getResource("engineer.json");
 
-		Engineer engineer = resourceConverter.readObject(data.getBytes(StandardCharsets.UTF_8), Engineer.class);
+		JSONAPIDocument<Engineer> engineerDocument = resourceConverter.readDocument(data, Engineer.class);
+
+		Engineer engineer = engineerDocument.get();
 
 		Assert.assertNotNull(engineer);
 		Assert.assertNotNull(engineer.getField());

--- a/src/test/java/com/github/jasminb/jsonapi/ValidationUtilsTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ValidationUtilsTest.java
@@ -50,7 +50,7 @@ public class ValidationUtilsTest {
 	@Test(expected = ResourceParseException.class)
 	public void testNodeIsError() throws IOException {
 		JsonNode node = mapper.readTree(IOUtils.getResourceAsString("errors.json"));
-		ValidationUtils.ensureNotError(node);
+		ValidationUtils.ensureNotError(mapper, node);
 	}
 
 	@Test

--- a/src/test/java/com/github/jasminb/jsonapi/retrofit/RetrofitTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/retrofit/RetrofitTest.java
@@ -1,11 +1,12 @@
 package com.github.jasminb.jsonapi.retrofit;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jasminb.jsonapi.ResourceConverter;
 import com.github.jasminb.jsonapi.models.errors.Error;
-import com.github.jasminb.jsonapi.models.errors.ErrorResponse;
 import com.github.jasminb.jsonapi.ErrorUtils;
 import com.github.jasminb.jsonapi.IOUtils;
 import com.github.jasminb.jsonapi.models.User;
+import com.github.jasminb.jsonapi.models.errors.Errors;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -98,7 +99,7 @@ public class RetrofitTest {
 
 		Assert.assertFalse(response.isSuccessful());
 
-		ErrorResponse errorResponse = ErrorUtils.parseErrorResponse(response.errorBody());
+		Errors errorResponse = ErrorUtils.parseErrorResponse(new ObjectMapper(), response.errorBody(), Errors.class);
 
 		Assert.assertNotNull(errorResponse);
 		Assert.assertEquals(1, errorResponse.getErrors().size());

--- a/src/test/java/com/github/jasminb/jsonapi/retrofit/SimpleService.java
+++ b/src/test/java/com/github/jasminb/jsonapi/retrofit/SimpleService.java
@@ -1,7 +1,7 @@
 package com.github.jasminb.jsonapi.retrofit;
 
 import com.github.jasminb.jsonapi.models.User;
-import com.github.jasminb.jsonapi.models.errors.ErrorResponse;
+import com.github.jasminb.jsonapi.models.errors.Errors;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
@@ -23,7 +23,7 @@ public interface SimpleService {
 	Call<List<User>> getExampleResourceList();
 
 	@GET("notanjsonapiendpoint")
-	Call<ErrorResponse> getNonJSONSPECResource();
+	Call<Errors> getNonJSONSPECResource();
 
 	@POST("user")
 	Call<User> createUser(@Body User user);


### PR DESCRIPTION
A few things happening here, sorry because everything goes into a single pull but the simplest way to fix the stuff that were not working for me was to copy over the project code into my api module.

I can cleanup things if you possibly want to pick out something off the pull.

What includes:

- Fix for https://github.com/jasminb/jsonapi-converter/issues/50 - I leave the option to make `Call<List<Employee>>` as well as to be able to do `Call<JSONAPIDocument<List<Employee>>` with retrofit when doing requests
- I refactored the ErrorUtils so that you are able to specify a custom mapper instance since usually you want to reuse that in the application and not create more than one. Also put in generic type so that you can parse into another class. Convenient for me since i put other methods into Errors such as checks for specific errors etc.. You can still parse into Errors. I renamed ErrorsResponse to Errors since it feels more appropriate with the rest of the naming structure in the project.
- Changed the readDocument() and readDocumentCollection from byte[] arrays to InputStreams. It offers a lot more options in terms of parameters and it should make the mapper work better since you are not loading a byte array first in memory but rather letting it read the stream.
- Fixed the tests to account for my changes.
- Removed the deprecated readObject stuff since it should be a pretty simple change to update it. no need to drag it along in future releases.
- Added the option to specify both a resourceConverter for the retrofit requestBody and the Response body. I've had cases in the module where i needed to serialize the body slightly differently.
