### PR TITLE
Fix handle relatonships when ALLOW_UNKNOWN_INCLUSIONS is true

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -349,24 +349,25 @@ public class ResourceConverter {
 
 		if (parent.has(INCLUDED)) {
 			// Get resources
-			List<Resource> includedResources = getIncludedResources(parent);
+			Map<String, Object> includedResources = getIncludedResources(parent);
 
 			if (!includedResources.isEmpty()) {
 				// Add to result
-				for (Resource includedResource : includedResources) {
-					result.put(includedResource.getIdentifier(), includedResource.getObject());
+				for (String identifier : includedResources.keySet()) {
+					result.put(identifier, includedResources.get(identifier));
 				}
 
 				ArrayNode includedArray = (ArrayNode) parent.get(INCLUDED);
-				for (int i = 0; i < includedResources.size(); i++) {
-					Resource resource = includedResources.get(i);
-
+				for (int i = 0; i < includedArray.size(); i++) {
 					// Handle relationships
 					JsonNode node = includedArray.get(i);
-					handleRelationships(node, resource.getObject());
+					Object resourceObject = includedResources.get(createIdentifier(node));
+						if ( resourceObject != null ){
+							handleRelationships(node, resourceObject);
+						}
 				}
 			}
-		}
+                }
 
 		return result;
 	}
@@ -379,9 +380,9 @@ public class ResourceConverter {
 	 * @throws IllegalAccessException
 	 * @throws InstantiationException
 	 */
-	private List<Resource> getIncludedResources(JsonNode parent)
+	private Map<String, Object> getIncludedResources(JsonNode parent)
 			throws IOException, IllegalAccessException, InstantiationException {
-		List<Resource> result = new ArrayList<>();
+		Map<String, Object> result = new HashMap<>();
 
 		if (parent.has(INCLUDED)) {
 			for (JsonNode jsonNode : parent.get(INCLUDED)) {
@@ -392,7 +393,7 @@ public class ResourceConverter {
 				if (clazz != null) {
 					Object object = readObject(jsonNode, clazz, false);
 					if (object != null) {
-						result.add(new Resource(createIdentifier(jsonNode), object));
+						result.put(createIdentifier(jsonNode), object);
 					}
 				} else if (!deserializationFeatures.contains(DeserializationFeature.ALLOW_UNKNOWN_INCLUSIONS)) {
 					throw new IllegalArgumentException("Included section contains unknown resource type: " + type);

--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -362,12 +362,12 @@ public class ResourceConverter {
 					// Handle relationships
 					JsonNode node = includedArray.get(i);
 					Object resourceObject = includedResources.get(createIdentifier(node));
-						if ( resourceObject != null ){
+						if (resourceObject != null){
 							handleRelationships(node, resourceObject);
 						}
 				}
 			}
-                }
+		}
 
 		return result;
 	}
@@ -916,24 +916,6 @@ public class ResourceConverter {
 	private RelationshipResolver getResolver(Class<?> type) {
 		RelationshipResolver resolver = typedResolvers.get(type);
 		return resolver != null ? resolver : globalResolver;
-	}
-
-	private static class Resource {
-		private String identifier;
-		private Object object;
-
-		public Resource(String identifier, Object resource) {
-			this.identifier = identifier;
-			this.object = resource;
-		}
-
-		public String getIdentifier() {
-			return identifier;
-		}
-
-		public Object getObject() {
-			return object;
-		}
 	}
 
 	/**

--- a/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
@@ -453,6 +453,21 @@ public class ResourceConverterTest {
 		Assert.assertNotNull(status);
 		Assert.assertEquals("content", status.getContent());
 		Assert.assertEquals("john", status.getUser().getName());
+
+		// Get and check the related statuses for the user
+		List<Status> statuses = status.getUser().getStatuses();
+		Assert.assertNotNull(statuses);
+		Assert.assertEquals(2, statuses.size());
+
+		for (Status relatedStatus : statuses) {
+			if (relatedStatus.getId().equals("myid")) {
+				Assert.assertEquals("myContent", relatedStatus.getContent());
+			} else if (relatedStatus.getId().equals("anotherid")) {
+				Assert.assertEquals("anotherContent", relatedStatus.getContent());
+			} else {
+				Assert.fail("Related status contain unexpected id: " + relatedStatus.getId());
+			}
+		}
 	}
 
 	@Test

--- a/src/test/resources/unknown-inclusions.json
+++ b/src/test/resources/unknown-inclusions.json
@@ -43,7 +43,7 @@
           "data": [
             {
               "type": "statuses",
-              "id": "id"
+              "id": "myid"
             },
             {
               "type": "statuses",
@@ -52,6 +52,24 @@
           ]
         }
       }
+    },
+    {
+       "type": "statuses",
+       "id": "anotherid",
+       "attributes": {
+          "content": "anotherContent",
+           "commentCount": 2,
+           "likeCount": 20
+        }
+    },
+    {
+       "type": "statuses",
+       "id": "myid",
+       "attributes": {
+          "content": "myContent",
+           "commentCount": 3,
+           "likeCount": 30
+        }
     }
   ]
 }


### PR DESCRIPTION
The logic in RescourceConverter.parseIncluded() that picks which node
of the included array to pass into handleRelationships can select the
incorrect node when the ALLOW_UNKNOWN_INCLUSIONS flag is true.

The logic assumes that the array of INCLUDED and the array
includeResources are the same size and same order.  This is not
true when the getIncludedResources() method is skipping unknown
resources.

This change uses Maps instead of arrays to explicitly get the correct
node from the INCLUDED objects to pass into handleRelationships

The change also has a update to the testEnableAllowUnknownInclusions()
test and associated unknown-inclusions.json.  The test now checks that
the correct statuses are added to the User object.