### PR TITLE
Fixes 130: KEBAB_CASE property naming strategy breaks relationship attribute removal

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.MapType;
@@ -773,6 +774,13 @@ public class ResourceConverter {
 		}
 		dataNode.set(ATTRIBUTES, attributesNode);
 
+		final PropertyNamingStrategy namingStrategy;
+		if (objectMapper.getPropertyNamingStrategy() != null) {
+			namingStrategy = objectMapper.getPropertyNamingStrategy();
+		}
+		else {
+			namingStrategy = new PropertyNamingStrategy();
+		}
 
 		// Handle relationships (remove from base type and add as relationships)
 		List<Field> relationshipFields = configuration.getRelationshipFields(object.getClass());
@@ -784,7 +792,7 @@ public class ResourceConverter {
 				Object relationshipObject = relationshipField.get(object);
 
 				if (relationshipObject != null) {
-					attributesNode.remove(relationshipField.getName());
+					attributesNode.remove(namingStrategy.nameForField(null, null, relationshipField.getName()));
 
 					Relationship relationship = configuration.getFieldRelationship(relationshipField);
 

--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -41,6 +41,7 @@ import static com.github.jasminb.jsonapi.JSONAPISpecConstants.*;
 public class ResourceConverter {
 	private final ConverterConfiguration configuration;
 	private final ObjectMapper objectMapper;
+	private final PropertyNamingStrategy namingStrategy;
 	private final Map<Class<?>, RelationshipResolver> typedResolvers = new HashMap<>();
 	private final ResourceCache resourceCache;
 	private final Set<DeserializationFeature> deserializationFeatures = DeserializationFeature.getDefaultFeatures();
@@ -94,6 +95,13 @@ public class ResourceConverter {
 			objectMapper = mapper;
 		} else {
 			objectMapper = new ObjectMapper();
+		}
+
+		// Object mapper's naming strategy is used if it is set
+		if (objectMapper.getPropertyNamingStrategy() != null) {
+			namingStrategy = objectMapper.getPropertyNamingStrategy();
+		} else {
+			namingStrategy = new PropertyNamingStrategy();
 		}
 
 		objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
@@ -773,14 +781,6 @@ public class ResourceConverter {
 			resourceCache.cache(resourceId.concat(configuration.getTypeName(object.getClass())), null);
 		}
 		dataNode.set(ATTRIBUTES, attributesNode);
-
-		final PropertyNamingStrategy namingStrategy;
-		if (objectMapper.getPropertyNamingStrategy() != null) {
-			namingStrategy = objectMapper.getPropertyNamingStrategy();
-		}
-		else {
-			namingStrategy = new PropertyNamingStrategy();
-		}
 
 		// Handle relationships (remove from base type and add as relationships)
 		List<Field> relationshipFields = configuration.getRelationshipFields(object.getClass());


### PR DESCRIPTION
If we use an ObjectMapper with a non-default property naming strategy (e.g. `PropertyNamingStrategy.KEBAB_CASE`) then relationship attributes with camel case member names may not get removed for the JSON API document.

For example, with regard to the test models, `integerIdResource` will remain the attribute list, even though it is listed as a relationship named `integer-id-resource` in the `LongIdResourceModel`.

This pull request adds a minimally invasive test case to capture the failure, and fixes the underlying cause.

I believe this is a critical bug: it makes this library unusable for non-trivial use with a non-default naming strategy like `KEBAB_CASE` (people like me!). Would love to see this/a fix soon in the Maven repositories :)