### PR TITLE
Fixes 105: parse all resources before handling data node's relationships

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -180,18 +180,25 @@ public class ResourceConverter {
 			ValidationUtils.ensureNotError(objectMapper, rootNode);
 			ValidationUtils.ensureValidResource(rootNode);
 
-			resourceCache.cache(parseIncluded(rootNode));
-
 			JsonNode dataNode = rootNode.get(DATA);
 
-			JSONAPIDocument<T> result;
-
+			// Parse data node without handling relationships
+			T resourceObject;
 			if (dataNode != null && dataNode.isObject()) {
-				T resourceObject = readObject(dataNode, clazz, true);
-				result = new JSONAPIDocument<>(resourceObject, objectMapper);
+				resourceObject = readObject(dataNode, clazz, false);
 			} else {
-				result = new JSONAPIDocument<>(null, objectMapper);
+				resourceObject = null;
 			}
+
+			// Parse all included resources
+			resourceCache.cache(parseIncluded(rootNode));
+
+			// Connect data node's relationships now that all resources have been parsed
+			if (resourceObject != null) {
+				handleRelationships(dataNode, resourceObject);
+			}
+
+			JSONAPIDocument<T> result = new JSONAPIDocument<>(resourceObject, objectMapper);
 
 			// Handle top-level meta
 			if (rootNode.has(META)) {
@@ -240,14 +247,27 @@ public class ResourceConverter {
 			ValidationUtils.ensureNotError(objectMapper, rootNode);
 			ValidationUtils.ensureValidResource(rootNode);
 
-			resourceCache.cache(parseIncluded(rootNode));
+			JsonNode dataNode = rootNode.get(DATA);
 
+			// Parse data node without handling relationships
 			List<T> resourceList = new ArrayList<>();
 
-			if (rootNode.has(DATA) && rootNode.get(DATA).isArray()) {
-				for (JsonNode element : rootNode.get(DATA)) {
-					T pojo = readObject(element, clazz, true);
+			if (dataNode != null && dataNode.isArray()) {
+				for (JsonNode element : dataNode) {
+					T pojo = readObject(element, clazz, false);
 					resourceList.add(pojo);
+				}
+			}
+
+			// Parse all included resources
+			resourceCache.cache(parseIncluded(rootNode));
+
+			// Connect data node's relationships now that all resources have been parsed
+			for (int i = 0; i < resourceList.size(); i++) {
+				JsonNode source = dataNode != null && dataNode.isArray() ? dataNode.get(i) : null;
+				T resourceObject = resourceList.get(i);
+				if (source != null && resourceObject != null) {
+					handleRelationships(source, resourceObject);
 				}
 			}
 			

--- a/src/test/java/com/github/jasminb/jsonapi/DeserializationTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/DeserializationTest.java
@@ -1,0 +1,39 @@
+package com.github.jasminb.jsonapi;
+
+import com.github.jasminb.jsonapi.models.Article;
+import com.github.jasminb.jsonapi.models.Author;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class DeserializationTest {
+    private ResourceConverter converter;
+
+    @Before
+    public void setup() {
+        converter = new ResourceConverter(Article.class, Author.class);
+    }
+
+    @Test
+    public void testCyclicalRelationshipDeserialization() throws IOException {
+        InputStream data = IOUtils.getResource("cyclical-relationship.json");
+        JSONAPIDocument<Author> deserialized = converter.readDocument(data, Author.class);
+
+        // Get the top-level Author
+        Author topLevelAuthorResource = deserialized.get();
+        // Get the Author through the cyclical relationship
+        Author cyclicalAuthorResource = deserialized.get().getArticles().iterator().next().getAuthor();
+
+        // Top-level Author and cyclical relationship Author should be the same object
+        Assert.assertEquals(topLevelAuthorResource, cyclicalAuthorResource);
+        // Top-level Author should preserve its attributes
+        Assert.assertNotNull(topLevelAuthorResource.getFirstName());
+        Assert.assertNotNull(topLevelAuthorResource.getLastName());
+        // Cyclical relationship Author should preserve its attributes
+        Assert.assertNotNull(cyclicalAuthorResource.getFirstName());
+        Assert.assertNotNull(cyclicalAuthorResource.getLastName());
+    }
+}

--- a/src/test/resources/cyclical-relationship.json
+++ b/src/test/resources/cyclical-relationship.json
@@ -1,0 +1,37 @@
+{
+  "data": {
+    "type": "people",
+    "id": "author-id",
+    "attributes": {
+      "firstName": "Test",
+      "lastName": "Author"
+    },
+    "relationships": {
+      "articles": {
+        "data": [
+          {
+            "type": "articles",
+            "id": "article-id"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "type": "articles",
+      "id": "article-id",
+      "attributes": {
+        "title": "Test Article"
+      },
+      "relationships": {
+        "author": {
+          "data": {
+            "type": "people",
+            "id": "author-id"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
As outlined in #105, there was an issue where a response that included the data node's resource as a relationship wasn't properly being parsed. This pull request changes the order of operations in `readDocument()` and `readDocumentCollection()` in order to fix this issue.

## Before ##
1. Parse all included resources
2. Parse `data` node including relationships

## After ##
1. Parse `data` node to warm the resource cache, but **do not** handle relationships
2. Parse all included resources
3. Handle `data` node's relationships now that the resource cache is fully populated