### PR TITLE
Fix for ClassCastException crash

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/retrofit/RetrofitType.java
+++ b/src/main/java/com/github/jasminb/jsonapi/retrofit/RetrofitType.java
@@ -33,8 +33,12 @@ public class RetrofitType {
         if (type instanceof ParameterizedType) {
             Type[] typeArgs = ((ParameterizedType) type).getActualTypeArguments();
             if (typeArgs != null && typeArgs.length > 0) {
-                this.type = (Class<?>) typeArgs[0];
-                this.collection = true;
+                if (typeArgs[0] instanceof Class<?>) {
+                    this.type = (Class<?>) typeArgs[0];
+                    this.collection = true;
+                } else {
+                    valid = false;
+                }
             } else {
                 valid = false;
             }


### PR DESCRIPTION
Fix for issue: https://github.com/jasminb/jsonapi-converter/issues/126

When RetrofitType was constructed with unexpected ParameterizedType. Unexpected type will from now on produce an invalid RetrofitType instance.

**Steps to reproduce:**

When using the same Retrofit ApiService interface for both jsonapi-converter integrated API calls and legacy API calls, ClassCastException might occur within RetrofitType class.

Example endpoint definition for which this  issue happens:

```
	@GET("users")
	Call<ApiService<Resource<Person>>> getPersons();
```

````
 class ApiResponse<T> {
        T data;

        ApiResponse(T data) {
            this.data = data;
        }
    }

    class Resource<T> {
        String id;
        T attributes;

        Resource(String id, T attributes) {
            this.id = id;
            this.attributes = attributes;
        }
    }

   class Person {
        String name;
        String lastName;

        Person(String name, String lastName) {
            this.name = name;
            this.lastName = lastName;
        }
    }

```