### PR TITLE
Add exception to throw when meta tag is not a Map

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
 import com.github.jasminb.jsonapi.exceptions.DocumentSerializationException;
+import com.github.jasminb.jsonapi.exceptions.InvalidMetaDataTypeException;
 import com.github.jasminb.jsonapi.exceptions.UnregisteredTypeException;
 import com.github.jasminb.jsonapi.models.errors.Error;
 
@@ -1026,10 +1027,9 @@ public class ResourceConverter {
 		try {
 			return objectMapper.readValue(p, mapType);
 		} catch (IOException e) {
-			// TODO: log? No recovery.
+			e.printStackTrace();
+			throw new InvalidMetaDataTypeException();
 		}
-
-		return null;
 	}
 
 	private ObjectNode addIncludedSection(ObjectNode rootNode, Map<String, ObjectNode> includedDataMap) {

--- a/src/main/java/com/github/jasminb/jsonapi/exceptions/InvalidMetaDataTypeException.java
+++ b/src/main/java/com/github/jasminb/jsonapi/exceptions/InvalidMetaDataTypeException.java
@@ -1,0 +1,20 @@
+package com.github.jasminb.jsonapi.exceptions;
+
+/**
+ * InvalidMetaDataTypeException implementation. <br/>
+ * This exception is thrown when a <a href="http://jsonapi.org/format/#document-meta">JSON-API meta object</a>
+ * that is provided is not a {@code Map}. It may be an array instead of a type that can be de-serialized
+ * to a {@code Map}.
+ *
+ * @author ianrumac.
+ */
+
+public class InvalidMetaDataTypeException extends RuntimeException {
+
+    /**
+     * Creates a new InvalidMetaDataTypeException.
+     */
+    public InvalidMetaDataTypeException() {
+        super("Failed to parse JSON-API meta object to a Map type.");
+    }
+}

--- a/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.github.jasminb.jsonapi.exceptions.DocumentSerializationException;
 import com.github.jasminb.jsonapi.exceptions.InvalidJsonApiResourceException;
+import com.github.jasminb.jsonapi.exceptions.InvalidMetaDataTypeException;
 import com.github.jasminb.jsonapi.exceptions.UnregisteredTypeException;
 import com.github.jasminb.jsonapi.models.Article;
 import com.github.jasminb.jsonapi.models.Author;
@@ -676,6 +677,12 @@ public class ResourceConverterTest {
 				Status.class);
 
 		Assert.assertNotNull(status.getMeta());
+	}
+
+	@Test(expected = InvalidMetaDataTypeException.class)
+	public void testInvalidMetaData() throws IOException {
+		InputStream apiResponse = IOUtils.getResource("users-outside-meta-invalid.json");
+		converter.readDocumentCollection(apiResponse, User.class);
 	}
 
 	@Test

--- a/src/test/resources/users-outside-meta-invalid.json
+++ b/src/test/resources/users-outside-meta-invalid.json
@@ -1,0 +1,19 @@
+{
+  "meta":[],
+  "data": [
+    {
+      "type": "users",
+      "id": "1",
+      "attributes": {
+        "name": "liz"
+      }
+    },
+    {
+      "type": "users",
+      "id": "2",
+      "attributes": {
+        "name": "john"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds a InvalidMetaDataTypeException to be thrown when the meta
data tag is not a map instead of catching the exception and
returning null and adds a testInvalidMetaData test to cover it.