### PR TITLE
Added addMeta and addLink methods to JSONAPIDocument

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/JSONAPIDocument.java
+++ b/src/main/java/com/github/jasminb/jsonapi/JSONAPIDocument.java
@@ -26,7 +26,7 @@ public class JSONAPIDocument<T> {
 	/**
 	 * A map of meta fields, keyed by the meta field name
 	 */
-	private Map<String, ?> meta;
+	private Map<String, Object> meta;
 
 
 	/**
@@ -84,7 +84,7 @@ public class JSONAPIDocument<T> {
 	 *
 	 * @return {@link Map} meta
 	 */
-	public Map<String, ?> getMeta() {
+	public Map<String, Object> getMeta() {
 		return meta;
 	}
 
@@ -93,8 +93,15 @@ public class JSONAPIDocument<T> {
 	 *
 	 * @param meta {@link Map} meta
 	 */
-	public void setMeta(Map<String, ?> meta) {
+	public void setMeta(Map<String, Object> meta) {
 		this.meta = new HashMap<>(meta);
+	}
+
+	public void addMeta(String key, Object value) {
+		if (meta == null) {
+			meta = new HashMap<>();
+		}
+		meta.put(key, value);
 	}
 
 	/**
@@ -104,6 +111,19 @@ public class JSONAPIDocument<T> {
 	 */
 	public Links getLinks() {
 		return links;
+	}
+
+	/**
+	 * Adds a named link.
+	 *
+	 * @param linkName the named link to add
+	 * @param link the link to add
+	 */
+	public void addLink(String linkName, Link link) {
+		if (links == null) {
+			links = new Links(new HashMap<String, Link>());
+		}
+		links.addLink(linkName, link);
 	}
 
 	/**

--- a/src/main/java/com/github/jasminb/jsonapi/JSONAPIDocument.java
+++ b/src/main/java/com/github/jasminb/jsonapi/JSONAPIDocument.java
@@ -84,7 +84,7 @@ public class JSONAPIDocument<T> {
 	 *
 	 * @return {@link Map} meta
 	 */
-	public Map<String, Object> getMeta() {
+	public Map<String, ?> getMeta() {
 		return meta;
 	}
 
@@ -93,7 +93,7 @@ public class JSONAPIDocument<T> {
 	 *
 	 * @param meta {@link Map} meta
 	 */
-	public void setMeta(Map<String, Object> meta) {
+	public void setMeta(Map<String, ?> meta) {
 		this.meta = new HashMap<>(meta);
 	}
 

--- a/src/main/java/com/github/jasminb/jsonapi/Links.java
+++ b/src/main/java/com/github/jasminb/jsonapi/Links.java
@@ -104,4 +104,13 @@ public class Links implements Serializable {
 		return new HashMap<>(links);
 	}
 
+	/**
+	 * Adds a named link.
+	 *
+	 * @param linkName name of the link to add
+	 * @param link the link to add
+	 */
+	public void addLink(String linkName, Link link) {
+		links.put(linkName, link);
+	}
 }

--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -1020,7 +1020,7 @@ public class ResourceConverter {
 	 * @param metaNode a JsonNode representing a meta object
 	 * @return a Map of the meta information, keyed by member name.
 	 */
-	private Map<String, ?> mapMeta(JsonNode metaNode) {
+	private Map<String, Object> mapMeta(JsonNode metaNode) {
 		JsonParser p = objectMapper.treeAsTokens(metaNode);
 		MapType mapType = TypeFactory.defaultInstance()
 				.constructMapType(HashMap.class, String.class, Object.class);

--- a/src/test/java/com/github/jasminb/jsonapi/JSONAPIDocumentTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/JSONAPIDocumentTest.java
@@ -1,0 +1,30 @@
+package com.github.jasminb.jsonapi;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Testing functionality of JSON API Document methods.
+ *
+ * @author Marcel Overdijk
+ */
+public class JSONAPIDocumentTest {
+
+    @Test
+    public void testAddMeta() {
+        JSONAPIDocument document = new JSONAPIDocument();
+        Assert.assertNull(document.getMeta());
+        document.addMeta("foo", "bar");
+        Assert.assertEquals(1, document.getMeta().size());
+        Assert.assertEquals("bar", document.getMeta().get("foo"));
+    }
+
+    @Test
+    public void testAddLink() {
+        JSONAPIDocument document = new JSONAPIDocument();
+        Assert.assertNull(document.getLinks());
+        document.addLink("foo", new Link("bar"));
+        Assert.assertEquals(1, document.getLinks().getLinks().size());
+        Assert.assertEquals("bar", document.getLinks().getLink("foo").getHref());
+    }
+}

--- a/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
@@ -603,7 +603,7 @@ public class ResourceConverterTest {
 
 		JSONAPIDocument<List<User>> usersDocument = converter.readDocumentCollection(usersRequest, User.class);
 
-		Map<String, String> meta = new HashMap<>();
+		Map<String, Object> meta = new HashMap<>();
 		meta.put("meta", "abc");
 
 		usersDocument.setMeta(meta);

--- a/src/test/java/com/github/jasminb/jsonapi/SerializationTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/SerializationTest.java
@@ -236,7 +236,7 @@ public class SerializationTest {
 
 		document.setLinks(user.links);
 
-		Map<String, String> globalMeta = new HashMap<>();
+		Map<String, Object> globalMeta = new HashMap<>();
 		globalMeta.put("key", "value");
 		document.setMeta(globalMeta);
 
@@ -268,7 +268,7 @@ public class SerializationTest {
 
 		document.setLinks(user.links);
 
-		Map<String, String> globalMeta = new HashMap<>();
+		Map<String, Object> globalMeta = new HashMap<>();
 		globalMeta.put("key", "value");
 		document.setMeta(globalMeta);
 


### PR DESCRIPTION
This PR (for issue #164) adds convenient helper methods for adding links and meta information like:

```
JSONAPIDocument document = new JSONAPIDocument();
document.addMeta("foo", "bar");
document.addLink(SELF, "some self link");
```

All existing tests passed but it has some consequences to existing users as

```
JSONAPIDocument document = new JSONAPIDocument();
Map<String, String> meta = new HashMap<>();
meta.put("foo", "bar");
document.setMet(meta);
```

won't work anymore. The map *needs* to be defined as `Map<String, Object>` so above example must be:

```
JSONAPIDocument document = new JSONAPIDocument();
Map<String, Object> meta = new HashMap<>();
meta.put("foo", "bar");
document.setMet(meta);
```

Note the current `JSONAPIDocument` `getMeta` and `getLinks` methods are unchanged. 
They still return `null` if not explicitly set or nothing is added.
I think this is best to have less impact on serializing configuration related to `null` values.
