### PR TITLE
Added constructor without initial map of links

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/Links.java
+++ b/src/main/java/com/github/jasminb/jsonapi/Links.java
@@ -21,6 +21,13 @@ public class Links implements Serializable {
 
 	/**
 	 * Create new Links.
+	 */
+	public Links() {
+		this.links = new HashMap<>();
+	}
+
+	/**
+	 * Create new Links.
 	 * @param linkMap {@link Map} link data
 	 */
 	public Links(Map<String, Link> linkMap) {


### PR DESCRIPTION
This would also allow:

```
Links links = new Links();
links.addLink("self", "some link")
```