### PR TITLE
Added @JsonInclude(Include.NON_NULL) to Link.meta + unit tests

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/Link.java
+++ b/src/main/java/com/github/jasminb/jsonapi/Link.java
@@ -1,5 +1,8 @@
 package com.github.jasminb.jsonapi;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 import java.io.Serializable;
 import java.util.Map;
 
@@ -10,6 +13,8 @@ public class Link implements Serializable {
 	private static final long serialVersionUID = -6509249812347545112L;
 	
 	private String href;
+
+	@JsonInclude(Include.NON_NULL)
 	private Map<String, ?> meta;
 	
 	/**

--- a/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
@@ -688,6 +688,41 @@ public class ResourceConverterTest {
 		converter.readDocument(apiResponse, User.class);
 	}
 
+	@Test
+	public void testWriteLinkWithMeta() throws Exception {
+		JSONAPIDocument<?> document = new JSONAPIDocument<>(null);
+
+		Map<String, Object> linkMeta = new HashMap<>();
+		linkMeta.put("meta", "abc");
+
+		Map<String, Link> linkMap = new HashMap<>();
+		linkMap.put("self", new Link("abc", linkMeta));
+
+		document.setLinks(new Links(linkMap));
+
+		String serialized = new String(converter.writeDocument(document));
+
+		String expected = "{\"links\":{\"self\":{\"href\":\"abc\",\"meta\":{\"meta\":\"abc\"}}}}";
+
+		Assert.assertEquals(expected, serialized);
+	}
+
+	@Test
+	public void testWriteLinkWithoutMeta() throws Exception {
+		JSONAPIDocument<?> document = new JSONAPIDocument<>(null);
+
+		Map<String, Link> linkMap = new HashMap<>();
+		linkMap.put("self", new Link("abc"));
+
+		document.setLinks(new Links(linkMap));
+
+		String serialized = new String(converter.writeDocument(document));
+
+		String expected = "{\"links\":{\"self\":{\"href\":\"abc\"}}}";
+
+		Assert.assertEquals(expected, serialized);
+	}
+
 	/**
 	 * Simple global RelationshipResolver implementation that maintains a count of responses for each
 	 * relationship url.


### PR DESCRIPTION
This makes sure links are not inluding `"meta": null` when the meta object of a link is `null`.