### PR TITLE
Changed internal map from HashMap to LinkedHashMap to preserve order

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/Links.java
+++ b/src/main/java/com/github/jasminb/jsonapi/Links.java
@@ -3,7 +3,7 @@ package com.github.jasminb.jsonapi;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.io.Serializable;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -23,7 +23,7 @@ public class Links implements Serializable {
 	 * Create new Links.
 	 */
 	public Links() {
-		this.links = new HashMap<>();
+		this.links = new LinkedHashMap<>();
 	}
 
 	/**
@@ -31,7 +31,7 @@ public class Links implements Serializable {
 	 * @param linkMap {@link Map} link data
 	 */
 	public Links(Map<String, Link> linkMap) {
-		this.links = new HashMap<>(linkMap);
+		this.links = new LinkedHashMap<>(linkMap);
 	}
 
 	/**
@@ -108,7 +108,7 @@ public class Links implements Serializable {
 	 * @return {@link Map} link data
 	 */
 	public Map<String, Link> getLinks() {
-		return new HashMap<>(links);
+		return new LinkedHashMap<>(links);
 	}
 
 	/**


### PR DESCRIPTION
The current impl using `HashMap` does not guarantee order.

E.g.:

```
JSONAPIDocument doc = new JSONAPIDocument(date)
doc.addLink(SELF, Link("http://example.com/"))
doc.addLink(FIRST, Link("http://example.com/"))
doc.addLink(PREV, Link("http://example.com/"))
doc.addLink(NEXT, Link("http://example.com/"))
doc.addLink(LAST, Link("http://example.com/))
```

was serializing it to:

```
"links": {
  "next": {
    "href": "http://example.com/",
    "meta": null
  },
  "self": {
    "href": "http://example.com/",
    "meta": null
  },
  "last": {
    "href": "http://example.com/",
    "meta": null
  },
  "first": {
    "href": "http://example.com/",
    "meta": null
  },
  "prev": {
    "href": "http://example.com/",
    "meta": null
  }
}
```

which was not preserving the order of adding the links to the `Links` object, and in this case gives a very unnatural ordering.

By using a `LinkedHashMap` (as proposed with this PR) the ordering of the links will be preserved.
