### PR TITLE
Introduced LinkSerializer for rendering shortened link

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/Link.java
+++ b/src/main/java/com/github/jasminb/jsonapi/Link.java
@@ -1,11 +1,18 @@
 package com.github.jasminb.jsonapi;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
 
 /**
  * Models a JSON API Link object.
  */
+@JsonSerialize(using = Link.LinkSerializer.class)
 public class Link implements Serializable {
 	private static final long serialVersionUID = -6509249812347545112L;
 	
@@ -78,5 +85,25 @@ public class Link implements Serializable {
 	@Override
 	public String toString() {
 		return String.valueOf(getHref());
+	}
+
+
+	protected static class LinkSerializer extends StdSerializer<Link> {
+
+		public LinkSerializer() {
+			super(Link.class);
+		}
+
+		@Override
+		public void serialize(Link link, JsonGenerator json, SerializerProvider provider) throws IOException {
+			if (link.getMeta() != null) {
+				json.writeStartObject();
+				json.writeStringField(JSONAPISpecConstants.HREF, link.getHref());
+				json.writeObjectField(JSONAPISpecConstants.META, link.getMeta());
+				json.writeEndObject();
+			} else {
+				json.writeString(link.getHref());
+			}
+		}
 	}
 }

--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.type.MapType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.github.jasminb.jsonapi.annotations.Relationship;
@@ -796,7 +797,12 @@ public class ResourceConverter {
 			dataNode.set(LINKS, jsonLinks);
 
 			if (jsonLinks.has(SELF)) {
-				selfHref = jsonLinks.get(SELF).get(HREF).asText();
+				JsonNode selfLink = jsonLinks.get(SELF);
+				if (selfLink instanceof TextNode) {
+					selfHref = selfLink.textValue();
+				} else {
+					selfHref = selfLink.get(HREF).asText();
+				}
 			}
 		}
 

--- a/src/test/java/com/github/jasminb/jsonapi/SerializationTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/SerializationTest.java
@@ -2,9 +2,6 @@ package com.github.jasminb.jsonapi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.github.jasminb.jsonapi.annotations.Relationship;
-import com.github.jasminb.jsonapi.annotations.RelationshipLinks;
-import com.github.jasminb.jsonapi.annotations.RelationshipMeta;
 import com.github.jasminb.jsonapi.exceptions.DocumentSerializationException;
 import com.github.jasminb.jsonapi.models.Article;
 import com.github.jasminb.jsonapi.models.Author;
@@ -229,6 +226,38 @@ public class SerializationTest {
 
 		Assert.assertFalse(new String(data).contains("user_relationship_meta"));
 		Assert.assertFalse(new String(data).contains("user_relationship_links"));
+	}
+
+	@Test
+	public void testLinkWithoutMeta() throws DocumentSerializationException {
+		User user = new User();
+		user.setName("Name");
+		Map<String, Link> linkMap = new HashMap<>();
+		linkMap.put(JSONAPISpecConstants.SELF, new Link("the-self-link"));
+		user.links = new Links(linkMap);
+
+		byte [] data = converter.writeDocument(new JSONAPIDocument<>(user));
+
+		Assert.assertFalse(new String(data).contains("href"));
+		Assert.assertTrue(new String(data).contains("the-self-link"));
+	}
+
+	@Test
+	public void testLinkWithMeta() throws DocumentSerializationException {
+		User user = new User();
+		user.setName("Name");
+		Map<String, String> meta = new HashMap<>();
+		meta.put("foo", "bar");
+		Map<String, Link> linkMap = new HashMap<>();
+		linkMap.put(JSONAPISpecConstants.SELF, new Link("the-self-link", meta));
+		user.links = new Links(linkMap);
+
+		byte [] data = converter.writeDocument(new JSONAPIDocument<>(user));
+
+		Assert.assertTrue(new String(data).contains("href"));
+		Assert.assertTrue(new String(data).contains("the-self-link"));
+		Assert.assertTrue(new String(data).contains("foo"));
+		Assert.assertTrue(new String(data).contains("bar"));
 	}
 
 	private JSONAPIDocument<User> createDocument(User user) {


### PR DESCRIPTION
Fix for #182 

When link has no meta it should render link as shortened version ("rel": "href")