### PR TITLE
Allow unknown type in relationship which the type is an interface

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/DeserializationFeature.java
+++ b/src/main/java/com/github/jasminb/jsonapi/DeserializationFeature.java
@@ -19,7 +19,13 @@ public enum DeserializationFeature {
 	 * This option determines whether encountering unknown types results in {@link IllegalArgumentException} being
 	 * thrown, or if parsing continues and the unknown field is ignored.
 	 */
-	ALLOW_UNKNOWN_INCLUSIONS(false);
+	ALLOW_UNKNOWN_INCLUSIONS(false),
+
+	/**
+	 * This option determines if relationship (collection) can have unknown type.
+	 * Can be use with polymorphic relationship.
+	 */
+	ALLOW_UNKNOWN_TYPE_IN_RELATIONSHIP(false);
 
 	private final boolean enabledByDefault;
 

--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -524,9 +524,17 @@ public class ResourceConverter {
 							}
 							relationshipField.set(object, elements);
 						} else {
+							try {
 							Object relationshipObject = parseRelationship(relationship.get(DATA), type);
-							if (relationshipObject != null) {
-								relationshipField.set(object, relationshipObject);
+								if (relationshipObject != null) {
+									relationshipField.set(object, relationshipObject);
+								}
+							} catch (UnregisteredTypeException ex) {
+								// Don't raise exception if the relationship is an interface and that we accept new type
+								if (relationshipField.getType().isInterface() &&
+										!deserializationFeatures.contains(DeserializationFeature.ALLOW_UNKNOWN_TYPE_IN_RELATIONSHIP)) {
+									throw ex;
+								}
 							}
 						}
 					}

--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -509,9 +509,17 @@ public class ResourceConverter {
 							Collection elements = createCollectionInstance(relationshipField.getType());
 
 							for (JsonNode element : relationship.get(DATA)) {
-								Object relationshipObject = parseRelationship(element, type);
-								if (relationshipObject != null) {
-									elements.add(relationshipObject);
+								try {
+									Object relationshipObject = parseRelationship(element, type);
+									if (relationshipObject != null) {
+										elements.add(relationshipObject);
+									}
+								} catch (Exception ex) {
+									// Don't raise exception if the relationship is an interface and that we accept new type
+									if (relationshipField.getType().isInterface() &&
+											!deserializationFeatures.contains(DeserializationFeature.ALLOW_UNKNOWN_TYPE_IN_RELATIONSHIP)) {
+										throw ex;
+									}
 								}
 							}
 							relationshipField.set(object, elements);

--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -514,7 +514,7 @@ public class ResourceConverter {
 									if (relationshipObject != null) {
 										elements.add(relationshipObject);
 									}
-								} catch (Exception ex) {
+								} catch (UnregisteredTypeException ex) {
 									// Don't raise exception if the relationship is an interface and that we accept new type
 									if (relationshipField.getType().isInterface() &&
 											!deserializationFeatures.contains(DeserializationFeature.ALLOW_UNKNOWN_TYPE_IN_RELATIONSHIP)) {

--- a/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
@@ -342,6 +342,26 @@ public class ResourceConverterTest {
 		Assert.assertNotNull(dealershipDocument.get().getAutomobiles());
 	}
 
+	@Test
+	public void testReadPolymorphicRelationshipsWithoutNewType() throws IOException {
+		ResourceConverter carConverter = new ResourceConverter("https://api.example.com", Car.class, Dealership.class);
+		carConverter.enableDeserializationOption(DeserializationFeature.ALLOW_UNKNOWN_INCLUSIONS);
+		InputStream apiResponse = IOUtils.getResource("cars2.json");
+
+		JSONAPIDocument<Dealership> dealershipDocument = carConverter.readDocument(apiResponse, Dealership.class);
+		Assert.assertNotNull(dealershipDocument.get().getAutomobiles());
+		/*
+		Failing with:
+		com.github.jasminb.jsonapi.exceptions.UnregisteredTypeException: No class was registered for type 'trucks'.
+			at com.github.jasminb.jsonapi.ResourceConverter.getActualType(ResourceConverter.java:1088)
+			at com.github.jasminb.jsonapi.ResourceConverter.readObject(ResourceConverter.java:330)
+			at com.github.jasminb.jsonapi.ResourceConverter.parseRelationship(ResourceConverter.java:571)
+			at com.github.jasminb.jsonapi.ResourceConverter.handleRelationships(ResourceConverter.java:512)
+			at com.github.jasminb.jsonapi.ResourceConverter.readDocument(ResourceConverter.java:217)
+			at com.github.jasminb.jsonapi.ResourceConverterTest.testReadPolymorphicRelationshipsWithoutNewType(ResourceConverterTest.java:351)
+		 */
+	}
+
 	@Test(expected = IllegalArgumentException.class)
 	public void testUsingNoTypeAnnotationClass() {
 		new ResourceConverter(String.class);

--- a/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
@@ -346,20 +346,11 @@ public class ResourceConverterTest {
 	public void testReadPolymorphicRelationshipsWithoutNewType() throws IOException {
 		ResourceConverter carConverter = new ResourceConverter("https://api.example.com", Car.class, Dealership.class);
 		carConverter.enableDeserializationOption(DeserializationFeature.ALLOW_UNKNOWN_INCLUSIONS);
+		carConverter.enableDeserializationOption(DeserializationFeature.ALLOW_UNKNOWN_TYPE_IN_RELATIONSHIP);
 		InputStream apiResponse = IOUtils.getResource("cars2.json");
 
 		JSONAPIDocument<Dealership> dealershipDocument = carConverter.readDocument(apiResponse, Dealership.class);
 		Assert.assertNotNull(dealershipDocument.get().getAutomobiles());
-		/*
-		Failing with:
-		com.github.jasminb.jsonapi.exceptions.UnregisteredTypeException: No class was registered for type 'trucks'.
-			at com.github.jasminb.jsonapi.ResourceConverter.getActualType(ResourceConverter.java:1088)
-			at com.github.jasminb.jsonapi.ResourceConverter.readObject(ResourceConverter.java:330)
-			at com.github.jasminb.jsonapi.ResourceConverter.parseRelationship(ResourceConverter.java:571)
-			at com.github.jasminb.jsonapi.ResourceConverter.handleRelationships(ResourceConverter.java:512)
-			at com.github.jasminb.jsonapi.ResourceConverter.readDocument(ResourceConverter.java:217)
-			at com.github.jasminb.jsonapi.ResourceConverterTest.testReadPolymorphicRelationshipsWithoutNewType(ResourceConverterTest.java:351)
-		 */
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/src/test/resources/cars2.json
+++ b/src/test/resources/cars2.json
@@ -1,0 +1,56 @@
+{
+  "data": {
+    "type": "dealerships",
+    "id": "1",
+    "attributes": {
+      "name": "Cars, Cars, Cars"
+    },
+    "links": {
+      "self": "http://example.com/dealerships/1"
+    },
+    "relationships": {
+      "inventory": {
+        "links": {
+          "self": "http://example.com/dealerships/1/relationships/inventory",
+          "related": "http://example.com/dealerships/1/inventory"
+        },
+        "data": [
+          { "type": "cars", "id": "2" },
+          { "type": "cars", "id": "3" },
+          { "type": "trucks", "id": "1" }
+        ]
+      }
+    }
+  },
+  "included": [{
+    "type": "cars",
+    "id": "2",
+    "attributes": {
+      "make": "BMW",
+      "model": "i8 Roadster"
+    },
+    "links": {
+      "self": "http://example.com/cars/2"
+    }
+  }, {
+    "type": "cars",
+    "id": "3",
+    "attributes": {
+      "make": "Volkswagon",
+      "model": "Golf GTI"
+    },
+    "links": {
+      "self": "http://example.com/cars/3"
+    }
+  }, {
+    "type": "trucks",
+    "id": "1",
+    "attributes": {
+      "make": "Tesla",
+      "model": "Semi"
+    },
+    "links": {
+      "self": "http://example.com/trucks/1"
+    }
+  }]
+}


### PR DESCRIPTION
Because interface means that new types can implements it, we can have an option for acting safely with that.

Long story can be read in PR https://github.com/jasminb/jsonapi-converter/pull/195 😄 