### PR TITLE
Add a configuration to inhibit the rendering of an empty 'attributes'

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -812,7 +812,6 @@ public class ResourceConverter {
 			// Cache the object for recursion breaking purposes
 			resourceCache.cache(resourceId.concat(configuration.getTypeName(object.getClass())), null);
 		}
-		dataNode.set(ATTRIBUTES, attributesNode);
 
 		// Handle relationships (remove from base type and add as relationships)
 		List<Field> relationshipFields = configuration.getRelationshipFields(object.getClass());
@@ -913,6 +912,20 @@ public class ResourceConverter {
 
 			if (relationshipsNode.size() > 0) {
 				dataNode.set(RELATIONSHIPS, relationshipsNode);
+			}
+		}
+
+		// Note: Attributes can be rendered once all other top
+		//       level object properties have been removed.
+		//       If done earlier, the presence of these properties
+		//       will cause the isEmpty test to fail in the case
+		//       of a configuration disallowing an empty
+		//       'attributes' tag to be rendered.
+		if (canSerializeEmptyAttributesTag(settings)) {
+			dataNode.set(ATTRIBUTES, attributesNode); // default
+		} else {
+			if (!attributesNode.isEmpty(null)) {
+				dataNode.set(ATTRIBUTES, attributesNode);
 			}
 		}
 
@@ -1230,6 +1243,13 @@ public class ResourceConverter {
 			return settings.serializeMeta();
 		}
 		return serializationFeatures.contains(SerializationFeature.INCLUDE_META);
+	}
+
+	private boolean canSerializeEmptyAttributesTag(SerializationSettings settings) {
+	  if (settings != null && settings.serializeEmptyAttributesTag() != null) {
+		  return settings.serializeEmptyAttributesTag();
+	  }
+	  return serializationFeatures.contains(SerializationFeature.ATTRIBUTES_TAG_ONLY_IF_NOT_EMPTY);
 	}
 
 	private JsonNode removeField(ObjectNode node, Field field) {

--- a/src/main/java/com/github/jasminb/jsonapi/SerializationFeature.java
+++ b/src/main/java/com/github/jasminb/jsonapi/SerializationFeature.java
@@ -24,9 +24,16 @@ public enum SerializationFeature {
 	/**
 	 * If enabled, links attribute will be serialized
 	 */
-	INCLUDE_LINKS(true);
+	INCLUDE_LINKS(true),
+
+	/**
+	 * If enabled, resources that only have
+	 * type and id will not render the attributes property.
+	 */
+	ATTRIBUTES_TAG_ONLY_IF_NOT_EMPTY(false);
 
 	final boolean enabled;
+
 
 	SerializationFeature(boolean enabled) {
 		this.enabled = enabled;

--- a/src/main/java/com/github/jasminb/jsonapi/SerializationSettings.java
+++ b/src/main/java/com/github/jasminb/jsonapi/SerializationSettings.java
@@ -13,6 +13,7 @@ public class SerializationSettings {
 	private List<String> relationshipExludes;
 	private Boolean serializeMeta;
 	private Boolean serializeLinks;
+	private Boolean serializeEmptyAttributesTag = true;
 	
 	private SerializationSettings() {
 		// Hide CTOR
@@ -52,6 +53,10 @@ public class SerializationSettings {
 		return serializeLinks;
 	}
 	
+	public Boolean serializeEmptyAttributesTag() {
+		return serializeEmptyAttributesTag;
+	}
+
 	/**
 	 * Serialisation settings builder.
 	 */
@@ -60,6 +65,7 @@ public class SerializationSettings {
 		private List<String> relationshipExludes = new ArrayList<>();
 		private Boolean serializeMeta;
 		private Boolean serializeLinks;
+		private Boolean serializeEmptyAttributesTag;
 		
 		/**
 		 * Explicitly enable relationship serialisation.
@@ -70,7 +76,7 @@ public class SerializationSettings {
 			relationshipIncludes.add(relationshipName);
 			return this;
 		}
-		
+
 		/**
 		 * Explicitly disable relationship serialisation.
 		 * @param relationshipName {@link String} relationship name
@@ -100,6 +106,11 @@ public class SerializationSettings {
 			serializeLinks = flag;
 			return this;
 		}
+
+		public Builder serializeEmptyAttributesTag(Boolean flag) {
+			serializeEmptyAttributesTag = flag;
+			return this;
+		}
 		
 		/**
 		 * Create new SerialisationSettings instance.
@@ -111,6 +122,7 @@ public class SerializationSettings {
 			result.relationshipExludes = new ArrayList<>(relationshipExludes);
 			result.serializeLinks = serializeLinks;
 			result.serializeMeta = serializeMeta;
+			result.serializeEmptyAttributesTag = serializeEmptyAttributesTag;
 			return result;
 		}
 	}

--- a/src/test/java/com/github/jasminb/jsonapi/models/SimpleResource.java
+++ b/src/test/java/com/github/jasminb/jsonapi/models/SimpleResource.java
@@ -1,0 +1,26 @@
+package com.github.jasminb.jsonapi.models;
+
+import com.github.jasminb.jsonapi.IntegerIdHandler;
+import com.github.jasminb.jsonapi.annotations.Id;
+import com.github.jasminb.jsonapi.annotations.Type;
+
+/**
+ * Model class used to test {@link Integer} as resource identifier.
+ *
+ * @author jbegic
+ */
+@Type("simple-resource-type")
+public class SimpleResource {
+	
+	@Id(IntegerIdHandler.class)
+	private Integer id;
+	
+	public Integer getId() {
+		return id;
+	}
+	
+	public void setId(Integer id) {
+		this.id = id;
+	}
+	
+}


### PR DESCRIPTION
The default behavior is to render an empty "attributes" tag for resources that have no attributes.  This patch allows for the serializer to be configured to prevent that from happening.  