### PR TITLE
add instruction to include the library into gradle project

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Maven:
 </dependency>
 ```
 
+Gradle:
+```groovy
+implementation 'com.github.jasminb:jsonapi-converter:0.9'
+```
+
 SBT:
 
 ```groovy


### PR DESCRIPTION
Gradle is a popular build tool for JVM and it is default on Android project. A short instruction to include the library into gradle project might help and save developers time.