### PR TITLE
add validation for resource objects/resource identifier objects (missing TYPE fix)

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -205,8 +205,8 @@ public class ResourceConverter {
 				} else {
 					resourceObject = readObject(dataNode, clazz, false);
 				}
-			} else if (dataNode != null && !dataNode.isNull()) {
-				throw new InvalidJsonApiResourceException("Primary data must be either a single resource object, a single resource identifier object, or null");
+			} else {
+				ValidationUtils.ensurePrimaryDataNull(dataNode);
 			}
 
 			// Parse all included resources

--- a/src/main/java/com/github/jasminb/jsonapi/ValidationUtils.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ValidationUtils.java
@@ -153,4 +153,10 @@ public class ValidationUtils {
 		return true;
 	}
 
+	public static void ensurePrimaryDataNull(JsonNode dataNode) {
+		if (dataNode != null && !dataNode.isNull()) {
+			throw new InvalidJsonApiResourceException("Primary data must be either a single resource object, a single resource identifier object, or null");
+		}
+	}
+
 }

--- a/src/main/java/com/github/jasminb/jsonapi/ValidationUtils.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ValidationUtils.java
@@ -19,37 +19,138 @@ public class ValidationUtils {
 	}
 
 	/**
-	 * Asserts that provided resource has required 'data' or 'meta' node.
-	 * @param resource resource
+	 * Ensures document has at least one of 'DATA', 'ERRORS' or 'META' attributes.
+	 *
+	 * @param resourceNode resource node
+	 * @throws ResourceParseException  Maps error attribute into ResourceParseException if present.
+	 * @throws InvalidJsonApiResourceException is thrown when node has none of the required attributes.
 	 */
-	public static void ensureValidResource(JsonNode resource) {
-		if (!resource.has(JSONAPISpecConstants.DATA) && !resource.has(JSONAPISpecConstants.META)) {
+	public static void ensureValidDocument(ObjectMapper mapper, JsonNode resourceNode) {
+		if (resourceNode == null || resourceNode.isNull()) {
 			throw new InvalidJsonApiResourceException();
 		}
-	}
 
-	/**
-	 * Returns <code>true</code> in case 'DATA' note has 'ID' and 'TYPE' attributes.
-	 * @param dataNode relationship data node
-	 * @return <code>true</code> if node has required attributes, else <code>false</code>
-	 */
-	public static boolean isRelationshipParsable(JsonNode dataNode) {
-		return dataNode != null && dataNode.hasNonNull(JSONAPISpecConstants.ID) && dataNode.hasNonNull(JSONAPISpecConstants.TYPE) &&
-				!dataNode.get(JSONAPISpecConstants.ID).isContainerNode() && !dataNode.get(JSONAPISpecConstants.TYPE).isContainerNode();
-	}
+		boolean hasErrors = resourceNode.hasNonNull(JSONAPISpecConstants.ERRORS);
+		boolean hasData = resourceNode.has(JSONAPISpecConstants.DATA);
+		boolean hasMeta = resourceNode.has(JSONAPISpecConstants.META);
 
-	/**
-	 * Ensures that provided node does not hold 'errors' attribute.
-	 * @param resourceNode resource node
-	 * @throws ResourceParseException
-	 */
-	public static void ensureNotError(ObjectMapper mapper, JsonNode resourceNode) {
-		if (resourceNode != null && resourceNode.hasNonNull(JSONAPISpecConstants.ERRORS)) {
+		if (hasErrors) {
 			try {
 				throw new ResourceParseException(ErrorUtils.parseError(mapper, resourceNode, Errors.class));
 			} catch (JsonProcessingException e) {
 				throw new RuntimeException(e);
 			}
 		}
+		if (!hasData && !hasMeta) {
+			throw new InvalidJsonApiResourceException();
+		}
 	}
+
+	/**
+	 * Returns <code>true</code> in case 'DATA' node is valid Resource Object or Resource Identifier Object.
+	 *
+	 * @param dataNode resource object data node
+	 * @return <code>true</code> if node is valid primary data object, else <code>false</code>
+	 */
+	public static boolean isValidObject(JsonNode dataNode) {
+		return isResourceObject(dataNode) || isResourceIdentifierObject(dataNode);
+	}
+
+	/**
+	 * Returns <code>true</code> in case 'DATA' node is Array containing only valid Resource Objects or Resource Identifier Objects.
+	 *
+	 * @param dataNode resource object data node
+	 * @return <code>true</code> if node has Array of valid primary data objects, else <code>false</code>
+	 */
+	public static boolean isValidArray(JsonNode dataNode) {
+		return isArrayOfResourceObjects(dataNode) || isArrayOfResourceIdentifierObjects(dataNode);
+	}
+
+	/**
+	 * Returns <code>true</code> in case node has 'ID' and 'TYPE' attributes.
+	 *
+	 * @param dataNode resource identifier object data node
+	 * @return <code>true</code> if node has required attributes and all attributes are valid, else <code>false</code>
+	 */
+	public static boolean isResourceIdentifierObject(JsonNode dataNode) {
+		return dataNode != null && dataNode.isObject() &&
+				hasValueNode(dataNode, JSONAPISpecConstants.ID) &&
+				hasValueNode(dataNode, JSONAPISpecConstants.TYPE) &&
+				hasContainerOrNull(dataNode, JSONAPISpecConstants.META);
+	}
+
+	/**
+	 * Returns <code>true</code> in case 'DATA' node has 'ATTRIBUTES' and 'TYPE' attributes.
+	 *
+	 * @param dataNode resource object data node
+	 * @return <code>true</code> if node has required attributes and all attributes are valid, else <code>false</code>
+	 */
+	public static boolean isResourceObject(JsonNode dataNode) {
+		return dataNode != null && dataNode.isObject() &&
+				hasValueOrNull(dataNode, JSONAPISpecConstants.ID) &&
+				hasValueNode(dataNode, JSONAPISpecConstants.TYPE) &&
+				hasContainerOrNull(dataNode, JSONAPISpecConstants.META) &&
+				hasContainerNode(dataNode, JSONAPISpecConstants.ATTRIBUTES) &&
+				hasContainerOrNull(dataNode, JSONAPISpecConstants.LINKS) &&
+				hasContainerOrNull(dataNode, JSONAPISpecConstants.RELATIONSHIPS);
+	}
+
+	/**
+	 * Returns <code>true</code> in case 'DATA' node has array of valid Resource Objects.
+	 *
+	 * @param dataNode resource object data node
+	 * @return <code>true</code> if node is empty array or contains only valid Resource Objects
+	 */
+	public static boolean isArrayOfResourceObjects(JsonNode dataNode) {
+		if (dataNode != null && dataNode.isArray()) {
+			for (JsonNode element : dataNode) {
+				if (!isResourceObject(element)) {
+					return false;
+				}
+			}
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Returns <code>true</code> in case 'DATA' node has array of valid Resource Identifier Objects.
+	 *
+	 * @param dataNode resource object data node
+	 * @return <code>true</code> if node is empty array or contains only valid Resource Identifier Objects
+	 */
+	public static boolean isArrayOfResourceIdentifierObjects(JsonNode dataNode) {
+		if (dataNode != null && dataNode.isArray()) {
+			for (JsonNode element : dataNode) {
+				if (!isResourceIdentifierObject(element)) {
+					return false;
+				}
+			}
+			return true;
+		}
+		return false;
+	}
+
+	private static boolean hasContainerNode(JsonNode dataNode, String attribute) {
+		return dataNode.hasNonNull(attribute) && dataNode.get(attribute).isContainerNode();
+	}
+
+	private static boolean hasValueNode(JsonNode dataNode, String attribute) {
+		return dataNode.hasNonNull(attribute) && dataNode.get(attribute).isValueNode();
+	}
+
+	private static boolean hasContainerOrNull(JsonNode dataNode, String attribute) {
+		if (dataNode.hasNonNull(attribute)) {
+			return dataNode.get(attribute).isContainerNode();
+		}
+		return true;
+	}
+
+	private static boolean hasValueOrNull(JsonNode dataNode, String attribute) {
+		if (dataNode.hasNonNull(attribute)) {
+			return dataNode.get(attribute).isValueNode();
+		}
+		return true;
+	}
+
 }

--- a/src/main/java/com/github/jasminb/jsonapi/ValidationUtils.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ValidationUtils.java
@@ -47,9 +47,57 @@ public class ValidationUtils {
 	}
 
 	/**
+	 * Ensures 'DATA' node is Array containing only valid Resource Objects or Resource Identifier Objects.
+	 *
+	 * @param dataNode array data node
+	 * @throws InvalidJsonApiResourceException is thrown when 'DATA' node is not an array of valid resource objects, an array of valid resource
+	 * identifier objects, or an empty array.
+	 */
+	public static void ensurePrimaryDataValidArray(JsonNode dataNode) {
+		if (!isArrayOfResourceObjects(dataNode) && !isArrayOfResourceIdentifierObjects(dataNode)) {
+			throw new InvalidJsonApiResourceException("Primary data must be an array of resource objects, an array of resource identifier objects, or an empty array ([])");
+		}
+	}
+
+	/**
+	 * Ensures 'DATA' node is a valid object, null or has JsonNode type NULL.
+	 *
+	 * @param dataNode data node.
+	 * @throws InvalidJsonApiResourceException is thrown when 'DATA' node is not valid object, null or null node.
+	 */
+	public static void ensurePrimaryDataValidObjectOrNull(JsonNode dataNode) {
+		if (!isValidObject(dataNode) && isNotNullNode(dataNode)) {
+			throw new InvalidJsonApiResourceException("Primary data must be either a single resource object, a single resource identifier object, or null");
+		}
+	}
+
+	/**
+	 * Ensures 'DATA' node is Array containing only valid Resource Objects.
+	 *
+	 * @param dataNode resource object array data node
+	 * @throws InvalidJsonApiResourceException is thrown when 'DATA' node is not an array of valid resource objects, or an empty array.
+	 */
+	public static void ensureValidResourceObjectArray(JsonNode dataNode) {
+		if (!isArrayOfResourceObjects(dataNode)) {
+			throw new InvalidJsonApiResourceException("Included must be an array of valid resource objects, or an empty array ([])");
+		}
+	}
+
+	/**
+	 * Returns  <code>true</code> in case 'DATA' node is not null and does not have JsonNode type NULL.
+	 *
+	 * @param dataNode data node.
+	 * @return <code>false</code> if node is null or is null node <code>true</code>
+	 * node.
+	 */
+	public static boolean isNotNullNode(JsonNode dataNode) {
+		return dataNode != null && !dataNode.isNull();
+	}
+
+	/**
 	 * Returns <code>true</code> in case 'DATA' node is valid Resource Object or Resource Identifier Object.
 	 *
-	 * @param dataNode resource object data node
+	 * @param dataNode object data node
 	 * @return <code>true</code> if node is valid primary data object, else <code>false</code>
 	 */
 	public static boolean isValidObject(JsonNode dataNode) {
@@ -57,20 +105,10 @@ public class ValidationUtils {
 	}
 
 	/**
-	 * Returns <code>true</code> in case 'DATA' node is Array containing only valid Resource Objects or Resource Identifier Objects.
-	 *
-	 * @param dataNode resource object data node
-	 * @return <code>true</code> if node has Array of valid primary data objects, else <code>false</code>
-	 */
-	public static boolean isValidArray(JsonNode dataNode) {
-		return isArrayOfResourceObjects(dataNode) || isArrayOfResourceIdentifierObjects(dataNode);
-	}
-
-	/**
 	 * Returns <code>true</code> in case node has 'ID' and 'TYPE' attributes.
 	 *
 	 * @param dataNode resource identifier object data node
-	 * @return <code>true</code> if node has required attributes and all attributes are valid, else <code>false</code>
+	 * @return <code>true</code> if node has required attributes and all provided attributes are valid, else <code>false</code>
 	 */
 	public static boolean isResourceIdentifierObject(JsonNode dataNode) {
 		return dataNode != null && dataNode.isObject() &&
@@ -83,7 +121,7 @@ public class ValidationUtils {
 	 * Returns <code>true</code> in case 'DATA' node has 'ATTRIBUTES' and 'TYPE' attributes.
 	 *
 	 * @param dataNode resource object data node
-	 * @return <code>true</code> if node has required attributes and all attributes are valid, else <code>false</code>
+	 * @return <code>true</code> if node has required attributes and all provided attributes are valid, else <code>false</code>
 	 */
 	public static boolean isResourceObject(JsonNode dataNode) {
 		return dataNode != null && dataNode.isObject() &&
@@ -98,7 +136,7 @@ public class ValidationUtils {
 	/**
 	 * Returns <code>true</code> in case 'DATA' node has array of valid Resource Objects.
 	 *
-	 * @param dataNode resource object data node
+	 * @param dataNode resource object array data node
 	 * @return <code>true</code> if node is empty array or contains only valid Resource Objects
 	 */
 	public static boolean isArrayOfResourceObjects(JsonNode dataNode) {
@@ -116,7 +154,7 @@ public class ValidationUtils {
 	/**
 	 * Returns <code>true</code> in case 'DATA' node has array of valid Resource Identifier Objects.
 	 *
-	 * @param dataNode resource object data node
+	 * @param dataNode resource identifier object array data node
 	 * @return <code>true</code> if node is empty array or contains only valid Resource Identifier Objects
 	 */
 	public static boolean isArrayOfResourceIdentifierObjects(JsonNode dataNode) {
@@ -151,12 +189,6 @@ public class ValidationUtils {
 			return dataNode.get(attribute).isValueNode();
 		}
 		return true;
-	}
-
-	public static void ensurePrimaryDataNull(JsonNode dataNode) {
-		if (dataNode != null && !dataNode.isNull()) {
-			throw new InvalidJsonApiResourceException("Primary data must be either a single resource object, a single resource identifier object, or null");
-		}
 	}
 
 }

--- a/src/main/java/com/github/jasminb/jsonapi/exceptions/InvalidJsonApiResourceException.java
+++ b/src/main/java/com/github/jasminb/jsonapi/exceptions/InvalidJsonApiResourceException.java
@@ -15,4 +15,11 @@ public class InvalidJsonApiResourceException extends RuntimeException {
     public InvalidJsonApiResourceException() {
         super("Resource must contain at least one of 'data', 'error' or 'meta' nodes.");
     }
+
+    /**
+     * Creates a new InvalidJsonApiResourceException.
+     */
+    public InvalidJsonApiResourceException(String errorMessage) {
+        super(errorMessage);
+    }
 }

--- a/src/main/java/com/github/jasminb/jsonapi/exceptions/InvalidJsonApiResourceException.java
+++ b/src/main/java/com/github/jasminb/jsonapi/exceptions/InvalidJsonApiResourceException.java
@@ -18,6 +18,8 @@ public class InvalidJsonApiResourceException extends RuntimeException {
 
     /**
      * Creates a new InvalidJsonApiResourceException.
+     *
+     * @param errorMessage detail message containing spec for resource that was invalid.
      */
     public InvalidJsonApiResourceException(String errorMessage) {
         super(errorMessage);

--- a/src/test/java/com/github/jasminb/jsonapi/ValidationUtilsTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ValidationUtilsTest.java
@@ -7,7 +7,9 @@ import com.github.jasminb.jsonapi.exceptions.InvalidJsonApiResourceException;
 import com.github.jasminb.jsonapi.exceptions.ResourceParseException;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 
@@ -19,61 +21,266 @@ import java.io.IOException;
 public class ValidationUtilsTest {
 	private ObjectMapper mapper;
 
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
 	@Before
 	public void setup() {
 		mapper = new ObjectMapper();
 	}
-	
+
+	//ensureValidDocument
+
 	@Test(expected = InvalidJsonApiResourceException.class)
 	public void testExpectData() throws IOException {
 		JsonNode node = mapper.readTree("{}");
-		ValidationUtils.ensureValidResource(node);
+		ValidationUtils.ensureValidDocument(mapper, node);
 	}
-	
+
 	@Test(expected = ResourceParseException.class)
 	public void testNodeIsError() throws IOException {
 		JsonNode node = mapper.readTree(IOUtils.getResourceAsString("errors.json"));
-		ValidationUtils.ensureNotError(mapper, node);
-	}
-
-	@Test
-	public void testRelationshipValidationPositive() throws IOException {
-		Assert.assertTrue(ValidationUtils.isRelationshipParsable(mapper.readTree("{\"type\" : \"type\", \"id\" : " +
-				"\"id\"}")));
-	}
-
-	@Test
-	public void testRelationshipValidationNoId() throws IOException {
-		Assert.assertFalse(ValidationUtils.isRelationshipParsable(mapper.readTree("{\"type\" : \"type\"}")));
-	}
-
-	@Test
-	public void testRelationshipValidationNoType() throws IOException {
-		Assert.assertFalse(ValidationUtils.isRelationshipParsable(mapper.readTree("{ \"id\" : \"id\"}")));
-	}
-
-	@Test
-	public void testRelationshipValidationEmpty() throws IOException {
-		Assert.assertFalse(ValidationUtils.isRelationshipParsable(mapper.readTree("{}")));
-	}
-
-	@Test
-	public void testRelationshipValidationNull() {
-		Assert.assertFalse(ValidationUtils.isRelationshipParsable(null));
-	}
-
-	@Test
-	public void testRelationshipValidationNullNode() {
-		Assert.assertFalse(ValidationUtils.isRelationshipParsable(NullNode.getInstance()));
+		ValidationUtils.ensureValidDocument(mapper, node);
 	}
 
 	@Test
 	public void nullObjectNode() throws IOException {
-		ValidationUtils.ensureValidResource(mapper.readTree("{\"data\" : null}"));
+		ValidationUtils.ensureValidDocument(mapper, mapper.readTree("{\"data\" : null}"));
 	}
-	
+
 	@Test
 	public void metaResource() throws IOException {
-		ValidationUtils.ensureValidResource(mapper.readTree("{\"meta\": {}}"));
+		ValidationUtils.ensureValidDocument(mapper, mapper.readTree("{\"meta\": {}}"));
 	}
+
+	//isResourceIdentifierObject
+
+	@Test
+	public void testResourceIdentifierValidationPositive() throws IOException {
+		Assert.assertTrue(ValidationUtils.isResourceIdentifierObject(mapper.readTree("{\"type\" : \"type\", \"id\" : " +
+				"\"id\"}")));
+	}
+
+	@Test
+	public void testResourceIdentifierValidationNoId() throws IOException {
+		Assert.assertFalse(ValidationUtils.isResourceIdentifierObject(mapper.readTree("{\"type\" : \"type\"}")));
+	}
+
+	@Test
+	public void testResourceIdentifierValidationIdNotValue() throws IOException {
+		Assert.assertFalse(ValidationUtils.isResourceIdentifierObject(mapper.readTree("{\"type\" : \"type\", \"id\" : {}}")));
+	}
+
+	@Test
+	public void testResourceIdentifierValidationNoType() throws IOException {
+		Assert.assertFalse(ValidationUtils.isResourceIdentifierObject(mapper.readTree("{ \"id\" : \"id\"}")));
+	}
+
+	@Test
+	public void testResourceIdentifierValidationTypeNotValue() throws IOException {
+		Assert.assertFalse(ValidationUtils.isResourceIdentifierObject(mapper.readTree("{\"type\" : {}, \"id\" : \"id\"}")));
+	}
+
+	@Test
+	public void testResourceIdentifierValidationMetaNotContainer() throws IOException {
+		Assert.assertFalse(ValidationUtils.isResourceIdentifierObject(mapper.readTree("{\"type\" : \"type\", \"meta\" : \"meta\", \"id\" : " +
+																							  "\"id\"}")));
+	}
+
+	@Test
+	public void testResourceIdentifierValidationMetaContainer() throws IOException {
+		Assert.assertTrue(ValidationUtils.isResourceIdentifierObject(mapper.readTree("{\"type\" : \"type\",\"meta\" : {}, \"id\" : " +
+																							 "\"id\"}")));
+	}
+
+	@Test
+	public void testResourceIdentifierValidationEmpty() throws IOException {
+		Assert.assertFalse(ValidationUtils.isResourceIdentifierObject(mapper.readTree("{}")));
+	}
+
+	@Test
+	public void testResourceIdentifierValidationNull() {
+		Assert.assertFalse(ValidationUtils.isResourceIdentifierObject(null));
+	}
+
+	@Test
+	public void testResourceIdentifierValidationNullNode() {
+		Assert.assertFalse(ValidationUtils.isResourceIdentifierObject(NullNode.getInstance()));
+	}
+
+    //isResourceObject
+
+    @Test
+    public void testResourceValidationPositive() throws IOException {
+        Assert.assertTrue(ValidationUtils.isResourceObject(mapper.readTree("{\"type\" : \"type\", \"attributes\" : {}}")));
+    }
+
+    @Test
+    public void testResourceValidationNoAttributes() throws IOException {
+        Assert.assertFalse(ValidationUtils.isResourceObject(mapper.readTree("{\"type\" : \"type\"}")));
+    }
+
+    @Test
+    public void testResourceValidationAttributesNotContainer() throws IOException {
+        Assert.assertFalse(ValidationUtils.isResourceObject(mapper.readTree("{\"type\" : \"type\", \"attributes\" : \"attributes\"}")));
+    }
+
+    @Test
+    public void testResourceValidationNoType() throws IOException {
+        Assert.assertFalse(ValidationUtils.isResourceObject(mapper.readTree("{ \"attributes\" : {}}")));
+    }
+
+    @Test
+    public void testResourceValidationTypeNotValue() throws IOException {
+        Assert.assertFalse(ValidationUtils.isResourceObject(mapper.readTree("{\"type\" : {}, \"attributes\" : {}}")));
+    }
+
+    @Test
+    public void testResourceValidationMetaNotContainer() throws IOException {
+        Assert.assertFalse(ValidationUtils.isResourceObject(mapper.readTree("{\"type\" : \"type\", \"meta\" : \"meta\", \"attributes\" : " +
+                                                                                    "{}}")));
+    }
+
+    @Test
+    public void testResourceValidationMetaContainer() throws IOException {
+        Assert.assertTrue(ValidationUtils.isResourceObject(mapper.readTree("{\"type\" : \"type\",\"meta\" : {}, \"attributes\" : " +
+                                                                                   "{}}")));
+    }
+
+    @Test
+    public void testResourceValidationRelationshipsNotContainer() throws IOException {
+        Assert.assertFalse(ValidationUtils.isResourceObject(mapper.readTree("{\"type\" : \"type\", \"relationships\" : \"Relationships\", "
+                                                                                    + "\"attributes\" : " +
+                                                                                    "{}}")));
+    }
+
+    @Test
+    public void testResourceValidationRelationshipsContainer() throws IOException {
+        Assert.assertTrue(ValidationUtils.isResourceObject(mapper.readTree("{\"type\" : \"type\",\"relationships\" : {}, \"attributes\" : " +
+                                                                                   "{}}")));
+    }
+
+    @Test
+    public void testResourceValidationLinksNotContainer() throws IOException {
+        Assert.assertFalse(ValidationUtils.isResourceObject(mapper.readTree("{\"type\" : \"type\", \"links\" : \"Links\", \"attributes\" : " +
+                                                                                    "{}}")));
+    }
+
+    @Test
+    public void testResourceValidationLinksContainer() throws IOException {
+        Assert.assertTrue(ValidationUtils.isResourceObject(mapper.readTree("{\"type\" : \"type\",\"links\" : {}, \"attributes\" : " +
+                                                                                   "{}}")));
+    }
+
+    @Test
+    public void testResourceValidationIdValue() throws IOException {
+        Assert.assertTrue(ValidationUtils.isResourceObject(mapper.readTree("{\"type\" : \"type\", \"id\" : \"Id\", \"attributes\" : " +
+                                                                                   "{}}")));
+    }
+
+    @Test
+    public void testResourceValidationIdNotValue() throws IOException {
+        Assert.assertFalse(ValidationUtils.isResourceObject(mapper.readTree("{\"type\" : \"type\",\"id\" : {}, \"attributes\" : {}}")));
+    }
+
+    @Test
+    public void testResourceValidationEmpty() throws IOException {
+        Assert.assertFalse(ValidationUtils.isResourceObject(mapper.readTree("{}")));
+    }
+
+    @Test
+    public void testResourceValidationNull() {
+        Assert.assertFalse(ValidationUtils.isResourceObject(null));
+    }
+
+    @Test
+    public void testResourceValidationNullNode() {
+        Assert.assertFalse(ValidationUtils.isResourceObject(NullNode.getInstance()));
+    }
+
+    //isArrayOfResourceObjects
+
+    @Test
+    public void testResourceArrayValidationPositive() throws IOException {
+        JsonNode dataNode = mapper.readTree("[{\"type\" : \"type\", \"attributes\" : {}}]");
+
+        Assert.assertTrue(ValidationUtils.isArrayOfResourceObjects(dataNode));
+    }
+
+    @Test
+    public void testResourceArrayValidationInvalidNode() throws IOException {
+        JsonNode dataNode = mapper.readTree("[{\"type\" : \"type\", \"attributes\" : \"attributes\"}]");
+
+        Assert.assertFalse(ValidationUtils.isArrayOfResourceObjects(dataNode));
+    }
+
+    @Test
+    public void testResourceArrayValidationInvalidNodeWithValidNode() throws IOException {
+        JsonNode dataNode = mapper.readTree(
+                "[{\"type\" : \"type\", \"attributes\" : {}} , "
+                        + "{\"type\" : \"type\", \"attributes\" : \"attributes\"}, "
+                        + "{\"type\" : \"type\", \"attributes\" : {}} ]");
+
+        Assert.assertFalse(ValidationUtils.isArrayOfResourceObjects(dataNode));
+    }
+
+    @Test
+    public void testResourceArrayValidationEmpty() throws IOException {
+        JsonNode dataNode = mapper.readTree("[]");
+
+        Assert.assertTrue(ValidationUtils.isArrayOfResourceObjects(dataNode));
+    }
+
+    @Test
+    public void testResourceArrayValidationNull() {
+        Assert.assertFalse(ValidationUtils.isArrayOfResourceObjects(null));
+    }
+
+    @Test
+    public void testResourceArrayValidationNullNode() {
+        Assert.assertFalse(ValidationUtils.isArrayOfResourceObjects(NullNode.getInstance()));
+    }
+
+    //isArrayOfResourceIdentifierObjects
+
+    @Test
+    public void testResourceIdentifierArrayValidationPositive() throws IOException {
+        JsonNode dataNode = mapper.readTree("[{\"type\" : \"type\", \"id\" : \"id\"}]");
+
+        Assert.assertTrue(ValidationUtils.isArrayOfResourceIdentifierObjects(dataNode));
+    }
+
+    @Test
+    public void testResourceIdentifierArrayValidationInvalidNode() throws IOException {
+        JsonNode dataNode = mapper.readTree("[{\"type\" : \"type\", \"id\" : {}}]");
+
+        Assert.assertFalse(ValidationUtils.isArrayOfResourceIdentifierObjects(dataNode));
+    }
+
+    @Test
+    public void testResourceIdentifierArrayValidationInvalidNodeWithValidNode() throws IOException {
+        JsonNode dataNode = mapper.readTree(
+                "[{\"type\" : \"type\", \"id\" : \"id\"} , "
+                        + "{\"type\" : \"type\", \"id\" : {}}, "
+                        + "{\"type\" : \"type\", \"id\" : \"id\"} ]");
+
+        Assert.assertFalse(ValidationUtils.isArrayOfResourceIdentifierObjects(dataNode));
+    }
+
+    @Test
+    public void testResourceIdentifierArrayValidationEmpty() throws IOException {
+        JsonNode dataNode = mapper.readTree("[]");
+
+        Assert.assertTrue(ValidationUtils.isArrayOfResourceIdentifierObjects(dataNode));
+    }
+
+    @Test
+    public void testResourceIdentifierArrayValidationNull() {
+        Assert.assertFalse(ValidationUtils.isArrayOfResourceIdentifierObjects(null));
+    }
+
+    @Test
+    public void testResourceIdentifierArrayValidationNullNode() {
+        Assert.assertFalse(ValidationUtils.isArrayOfResourceIdentifierObjects(NullNode.getInstance()));
+    }
 }

--- a/src/test/resources/missing-type-collection.json
+++ b/src/test/resources/missing-type-collection.json
@@ -1,0 +1,8 @@
+{
+  "data": [{
+    "id": "userId",
+    "attributes": {
+      "name": "liz"
+    }
+  }]
+}

--- a/src/test/resources/missing-type-inclusion.json
+++ b/src/test/resources/missing-type-inclusion.json
@@ -1,0 +1,45 @@
+{
+  "data": {
+    "type": "engineer",
+    "id": "id",
+    "attributes": {
+      "firstName": "John",
+      "lastName": "Doe"
+    },
+    "relationships": {
+      "field": {
+        "data": {
+          "type": "engineering_field",
+          "id": "field_id"
+        }
+      },
+      "city": {
+        "data": {
+          "type": "city",
+          "id": "city_id"
+        }
+      }
+    },
+    "meta": {
+      "note" : "Note"
+    }
+  },
+  "included": [
+    {
+      "id": "field_id",
+      "attributes": {
+        "name": "Software Engineering"
+      }
+    },
+    {
+      "type": "city",
+      "id": "city_id",
+      "attributes": {
+        "name": "Sarajevo"
+      }
+    }
+  ],
+  "meta": {
+    "note" : "Note"
+  }
+}

--- a/src/test/resources/missing-type-relationship.json
+++ b/src/test/resources/missing-type-relationship.json
@@ -1,0 +1,44 @@
+{
+  "data": {
+    "type": "engineer",
+    "id": "id",
+    "attributes": {
+      "firstName": "John",
+      "lastName": "Doe"
+    },
+    "relationships": {
+      "field": {
+        "data": {
+          "id": "field_id"
+        }
+      },
+      "city": {
+        "data": {
+          "id": "city_id"
+        }
+      }
+    },
+    "meta": {
+      "note" : "Note"
+    }
+  },
+  "included": [
+    {
+      "type": "engineering_field",
+      "id": "field_id",
+      "attributes": {
+        "name": "Software Engineering"
+      }
+    },
+    {
+      "type": "city",
+      "id": "city_id",
+      "attributes": {
+        "name": "Sarajevo"
+      }
+    }
+  ],
+  "meta": {
+    "note" : "Note"
+  }
+}

--- a/src/test/resources/missing-type.json
+++ b/src/test/resources/missing-type.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "id": "userId",
+    "attributes": {
+      "name": "liz"
+    }
+  }
+}


### PR DESCRIPTION
I made these changes as missing `TYPE` attribute in the `DATA` node was causing a null pointer in `ResourceConverter.createIdentifier`. I ended up adding some extra validation 🤷‍♀ 

Shortlist of changes:
- DATA node must be valid primary data:

- - `a single resource object, a single resource identifier object, or null, for requests that target single resources`
- - `an array of resource objects, an array of resource identifier objects, or an empty array ([]), for requests that target resource collections`

- `TYPE` and `ATTRIBUTES` attributes now required for `resource objects`
- null `DATA` not allowed in `readDocumentCollection` must be `[]`
- null `DATA` still fine for `readDocument`
- enforcing node types on attributes (e.g. `META` must be a `containerNode`, `TYPE` must be a `valueNode`)
- `INCLUDED` relationships must be an array of valid resource objects, or an empty array 
- `RELATIONSHIPS` `DATA` objects must be valid resource identifier objects, no exception thrown for invalid but they will be skipped along with any valid `INCLUDED` relationships objects (not sure if I should throw an exception here?)