### PR TITLE
Add option to prevent serialization of the data section of a relationship

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/annotations/Relationship.java
+++ b/src/main/java/com/github/jasminb/jsonapi/annotations/Relationship.java
@@ -19,6 +19,7 @@ public @interface Relationship {
 	String value();
 	boolean resolve() default false;
 	boolean serialise() default true;
+	boolean serialiseData() default true;
 	RelType relType() default RelType.SELF;
 	
 	/**

--- a/src/test/java/com/github/jasminb/jsonapi/models/Article.java
+++ b/src/test/java/com/github/jasminb/jsonapi/models/Article.java
@@ -3,11 +3,14 @@ package com.github.jasminb.jsonapi.models;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.github.jasminb.jsonapi.Links;
 import com.github.jasminb.jsonapi.RelType;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Id;
+import com.github.jasminb.jsonapi.annotations.RelationshipLinks;
 import com.github.jasminb.jsonapi.annotations.Type;
 
+import java.util.Collections;
 import java.util.List;
 
 @Type("articles")
@@ -24,6 +27,15 @@ public class Article {
 	@Relationship(value = "comments", resolve = true)
 	private List<Comment> comments;
 
+	@Relationship(value = "users", serialiseData = false)
+	private List<User> users;
+
+	@RelationshipLinks(value = "users")
+	private Links userRelationshipLinks;
+
+	public Article() {
+		users = Collections.emptyList();
+	}
 
 	public String getId() {
 		return id;
@@ -55,5 +67,21 @@ public class Article {
 
 	public void setComments(List<Comment> comments) {
 		this.comments = comments;
+	}
+
+	public List<User> getUsers() {
+		return users;
+	}
+
+	public void setUsers(List<User> users) {
+		this.users = users;
+	}
+
+	public Links getUserRelationshipLinks() {
+		return userRelationshipLinks;
+	}
+
+	public void setUserRelationshipLinks(Links userRelationshipLinks) {
+		this.userRelationshipLinks = userRelationshipLinks;
 	}
 }

--- a/src/test/resources/articles.json
+++ b/src/test/resources/articles.json
@@ -25,6 +25,12 @@
           { "type": "comments", "id": "5" },
           { "type": "comments", "id": "12" }
         ]
+      },
+      "users": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/users",
+          "related": "http://example.com/articles/1/users"
+        }
       }
     }
   }],


### PR DESCRIPTION
These changes are intended to fix issue #186 (`@RelationshipLinks` without `@Relationship` not working). The JSON:API spec does not require that relationship objects contain `data`. Until now, it was not possible avoid serialization of relationship `data` even if it will never be populated.

Implementation:
I've extended the `@Relationship` annotation with a new `serialiseData` field. Existing behavior is retained by default, making this a non-breaking change. Setting `serialiseData` to `false` will disable serialization of the `data` section. It will also prevent generation of `included` resources for the annotated relationship.