### PR TITLE
Support to write links or meta fields but no data filed in relationship objects.

### DIFF
--- a/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
@@ -804,6 +804,20 @@ public class ResourceConverterTest {
 	}
 
 	@Test
+	public void testWriteRelationshipWithoutData() throws IOException, DocumentSerializationException {
+		InputStream statusStream = IOUtils.getResource("status.json");
+		JSONAPIDocument<Status> statusJSONAPIDocument = converter.readDocument(statusStream, Status.class);
+		statusJSONAPIDocument.get().setRelatedUser(null);
+		byte [] serialized = converter.writeDocument(statusJSONAPIDocument);
+
+		Status status = converter.readDocument(serialized, Status.class).get();
+		assertNotNull(status.getUserRelationshipLinks());
+		assertEquals("users/userid", status.getUserRelationshipLinks().getSelf().getHref());
+
+		assertNull(status.getRelatedUser());
+	}
+
+	@Test
 	public void testReadMetaOnly() {
 		JSONAPIDocument<Status> status = converter.readDocument("{\"meta\" : {}}".getBytes(StandardCharsets.UTF_8),
 				Status.class);


### PR DESCRIPTION
Hi Team,

We were working on some projects using jsonapi-converter library to make sure our response is strictly following the standard.

We met a problem when we write relationship objects.
For the reason of reducing the data size, we would like to only write links out, but without embedding Included resource objects in `included` field. 
The most similar issue is https://github.com/jasminb/jsonapi-converter/issues/186

To implement above requirement and resolve the problem.
We did a simply change. It can allow users to only write links or meta fields but no data filed in relationship objects.

Usage: Simply set the Relationship field to null at runtime.

Given the Relationship field are equals to null, so it will also not appears in Included resource objects.


Could team review it, thanks a lot.

Peace and Long Life,
Boris
