### PR TITLE
allow alternate typenames

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/ConverterConfiguration.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ConverterConfiguration.java
@@ -54,7 +54,9 @@ public class ConverterConfiguration {
 	private void processClass(Class<?> clazz) {
 		if (clazz.isAnnotationPresent(Type.class)) {
 			Type annotation = clazz.getAnnotation(Type.class);
-			typeToClassMapping.put(annotation.value(), clazz);
+			for (String typeName : annotation.value()) {
+				typeToClassMapping.put(typeName, clazz);
+			}
 			typeAnnotations.put(clazz, annotation);
 			relationshipTypeMap.put(clazz, new HashMap<String, Class<?>>());
 			relationshipFieldMap.put(clazz, new HashMap<String, Field>());
@@ -286,7 +288,7 @@ public class ConverterConfiguration {
 		Type type = typeAnnotations.get(clazz);
 
 		if (type != null) {
-			return type.value();
+			return type.value()[0];
 		}
 		return null;
 	}

--- a/src/main/java/com/github/jasminb/jsonapi/ReflectionUtils.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ReflectionUtils.java
@@ -51,7 +51,7 @@ public class ReflectionUtils {
 	 * @param clazz type class
 	 * @return name of the type or <code>null</code> in case Type annotation is not present
 	 */
-	public static String getTypeName(Class<?> clazz) {
+	public static String[] getTypeNames(Class<?> clazz) {
 		Type typeAnnotation = clazz.getAnnotation(Type.class);
 		return typeAnnotation != null ? typeAnnotation.value() : null;
 	}

--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -130,9 +130,9 @@ public class ResourceConverter {
 	 */
 	public void setTypeResolver(RelationshipResolver resolver, Class<?> type) {
 		if (resolver != null) {
-			String typeName = ReflectionUtils.getTypeName(type);
+			String[] typeNames = ReflectionUtils.getTypeNames(type);
 
-			if (typeName != null) {
+			if (typeNames != null) {
 				typedResolvers.put(type, resolver);
 			}
 		}

--- a/src/main/java/com/github/jasminb/jsonapi/annotations/Type.java
+++ b/src/main/java/com/github/jasminb/jsonapi/annotations/Type.java
@@ -16,8 +16,8 @@ public @interface Type {
 	/**
 	 * Resource type name.
 	 */
-	String value();
-	
+	String[] value();
+
 	/**
 	 * Resource path, used to generate <code>self</code> link.
 	 */

--- a/src/test/java/com/github/jasminb/jsonapi/models/Article.java
+++ b/src/test/java/com/github/jasminb/jsonapi/models/Article.java
@@ -13,7 +13,7 @@ import com.github.jasminb.jsonapi.annotations.Type;
 import java.util.Collections;
 import java.util.List;
 
-@Type("articles")
+@Type({"article", "articles"})
 @JsonIdentityInfo(generator = ObjectIdGenerators.StringIdGenerator.class, property = "id")
 public class Article {
 	@Id

--- a/src/test/java/com/github/jasminb/jsonapi/models/Comment.java
+++ b/src/test/java/com/github/jasminb/jsonapi/models/Comment.java
@@ -5,7 +5,7 @@ import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
 
-@Type("comments")
+@Type({"comments", "comment"})
 public class Comment {
 	@Id
 	private String id;

--- a/src/test/java/com/github/jasminb/jsonapi/models/inheritance/Engineer.java
+++ b/src/test/java/com/github/jasminb/jsonapi/models/inheritance/Engineer.java
@@ -8,7 +8,7 @@ import com.github.jasminb.jsonapi.annotations.Type;
  *
  * @author jbegic
  */
-@Type("engineer")
+@Type({"engineer", "engineers"})
 public class Engineer extends Person {
 
 	@Relationship("field")

--- a/src/test/resources/articles-with-link-objects.json
+++ b/src/test/resources/articles-with-link-objects.json
@@ -1,6 +1,6 @@
 {
   "data": [{
-    "type": "articles",
+    "type": "article",
     "id": "1",
     "attributes": {
       "title": "JSON API paints my bikeshed!"
@@ -48,7 +48,7 @@
       "self": "http://example.com/people/9"
     }
   }, {
-    "type": "comments",
+    "type": "comment",
     "id": "5",
     "attributes": {
       "body": "First!"
@@ -62,7 +62,7 @@
       "self": "http://example.com/comments/5"
     }
   }, {
-    "type": "comments",
+    "type": "comment",
     "id": "12",
     "attributes": {
       "body": "I like XML better"

--- a/src/test/resources/articles.json
+++ b/src/test/resources/articles.json
@@ -1,6 +1,6 @@
 {
   "data": [{
-    "type": "articles",
+    "type": "article",
     "id": "1",
     "attributes": {
       "title": "JSON API paints my bikeshed!"

--- a/src/test/resources/missing-type-inclusion.json
+++ b/src/test/resources/missing-type-inclusion.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "type": "engineer",
+    "type": "engineers",
     "id": "id",
     "attributes": {
       "firstName": "John",


### PR DESCRIPTION
This is to handle the case, where some server side serialization libraries might mixup singular and plural type names. 

An example are these two nodejs libraries 

https://www.npmjs.com/package/jsonapi-serializer - produces plurals
https://www.npmjs.com/package/json-api-serializer - produces singulars

We can now support multiple types 

```java
@Type({"comments", "comment"})
public class Comment {
	@Id
	private String id;
	private String body;
	// ...
}

```

Signed-off-by: Arnav Gupta <arnav@codingblocks.com>