### PR TITLE
fixes a bug where ALLOW_UNKNOWN_INCLUSIONS wasn't checked before perf…

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -420,7 +420,9 @@ public class ResourceConverter {
 		Map<String, Object> result = new HashMap<>();
 
 		JsonNode included = parent.get(INCLUDED);
-		ValidationUtils.ensureValidResourceObjectArray(included);
+		if (!deserializationFeatures.contains(DeserializationFeature.ALLOW_UNKNOWN_INCLUSIONS)) {
+			ValidationUtils.ensureValidResourceObjectArray(included);
+		}
 		for (JsonNode jsonNode : included) {
 			String type = jsonNode.get(TYPE).asText();
 			Class<?> clazz = configuration.getTypeClass(type);

--- a/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
@@ -538,6 +538,19 @@ public class ResourceConverterTest {
 		}
 	}
 
+	/**
+	 * Added to test a regression introduced in 0.10.
+	 *
+	 * @throws IOException
+	 */
+	@Test
+	public void testEnableAllowUnknownInclusionsTwo() throws IOException {
+		converter.enableDeserializationOption(DeserializationFeature.ALLOW_UNKNOWN_INCLUSIONS);
+
+		InputStream rawData = IOUtils.getResource("included_fail.json");
+		converter.readDocument(rawData, City.class).get();
+	}
+
 	@Test
 	public void testNullDataNodeObject() {
 		JSONAPIDocument<User> nullObject = converter.readDocument("{\"data\" : null}".getBytes(), User.class);

--- a/src/test/resources/included_fail.json
+++ b/src/test/resources/included_fail.json
@@ -1,0 +1,25 @@
+{
+    "data": {
+        "attributes": {
+            "name": "test name"
+        },
+        "id": "yaddayadda",
+        "relationships": {
+            "items": {
+                "data": [
+                    {
+                        "id": "123",
+                        "type": "undefined_subtype"
+                    }
+                ]
+            }
+        },
+        "type": "city"
+    },
+    "included": [
+        {
+            "id": "123",
+            "type": "undefined_subtype"
+        }
+    ]
+}


### PR DESCRIPTION
…orming a more thorough check of 'included'

I believe commit 6e5f1d479ae1d27eceeaec81d1df7fdf57c0f66e introduced this regression. There's a new json resource and unit test that fails in 0.10 but passes in this branch. All other unit tests (including the ones added as part of 6e5f1d479ae1d27eceeaec81d1df7fdf57c0f66e) still pass.