### PR TITLE
Allowing relationship links to get serialized for null relationship object

### DIFF
--- a/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
@@ -127,6 +127,13 @@ public class ResourceConverterTest {
 
 		JSONAPIDocument<List<User>> usersDocument = converter.readDocumentCollection(usersRequest, User.class);
 		List<User> users = usersDocument.get();
+
+		assertNotNull(users);
+		assertEquals(2, users.size());
+
+		// Make sure that relationship object i.e. statuses is null
+		assertNull(users.get(0).getStatuses());
+
 		byte[] convertedData = converter.writeObjectCollection(users);
 
 		assertNotNull(convertedData);
@@ -140,7 +147,21 @@ public class ResourceConverterTest {
 		ObjectMapper mapper = new ObjectMapper();
 		try {
 			JsonNode node1 = mapper.readTree(IOUtils.getResource("users.json"));
+
+			// Make sure relationship node always get serialized even if relationship object i.e. statuses is null
+			JsonNode user1Relationships = node1.get("data").get(0).get("relationships");
+			assertNotNull(user1Relationships.get("statuses"));
+
+			JsonNode user2Relationships = node1.get("data").get(1).get("relationships");
+			assertNotNull(user2Relationships.get("statuses"));
+
 			JsonNode node2 = mapper.readTree(convertedData);
+			user1Relationships = node2.get("data").get(0).get("relationships");
+			assertNotNull(user1Relationships.get("statuses"));
+
+			user2Relationships = node2.get("data").get(1).get("relationships");
+			assertNotNull(user2Relationships.get("statuses"));
+
 			assertEquals(node1, node2);
 		} catch (IOException e) {
 			throw new RuntimeException("Unable to read json, make sure is correct", e);

--- a/src/test/java/com/github/jasminb/jsonapi/models/Article.java
+++ b/src/test/java/com/github/jasminb/jsonapi/models/Article.java
@@ -13,7 +13,7 @@ import com.github.jasminb.jsonapi.annotations.Type;
 import java.util.Collections;
 import java.util.List;
 
-@Type("articles")
+@Type(value = "articles", path = "/articles/{id}")
 @JsonIdentityInfo(generator = ObjectIdGenerators.StringIdGenerator.class, property = "id")
 public class Article {
 	@Id
@@ -24,8 +24,11 @@ public class Article {
 	@Relationship(value = "author", resolve = true, relType = RelType.RELATED)
 	private Author author;
 
-	@Relationship(value = "comments", resolve = true)
+	@Relationship(value = "comments", resolve = true, path = "relationships/comments", relatedPath = "comments")
 	private List<Comment> comments;
+
+    @RelationshipLinks(value = "comments")
+    private Links commentRelationshipLinks;
 
 	@Relationship(value = "users", serialiseData = false)
 	private List<User> users;
@@ -84,4 +87,12 @@ public class Article {
 	public void setUserRelationshipLinks(Links userRelationshipLinks) {
 		this.userRelationshipLinks = userRelationshipLinks;
 	}
+
+    public Links getCommentRelationshipLinks() {
+        return commentRelationshipLinks;
+    }
+
+    public void setCommentRelationshipLinks(Links commentRelationshipLinks) {
+        this.commentRelationshipLinks = commentRelationshipLinks;
+    }
 }

--- a/src/test/resources/articles-with-non-included-empty-to-many-relationship.json
+++ b/src/test/resources/articles-with-non-included-empty-to-many-relationship.json
@@ -1,0 +1,39 @@
+{
+  "data": [{
+    "type": "articles",
+    "id": "1",
+    "attributes": {
+      "title": "JSON API paints my bikeshed!"
+    },
+    "links": {
+      "self": "http://example.com/articles/1"
+    },
+    "relationships": {
+      "author": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/author",
+          "related": "http://example.com/articles/1/author"
+        },
+        "data": { "type": "people", "id": "9" }
+      },
+      "users": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/users",
+          "related": "http://example.com/articles/1/users"
+        }
+      }
+    }
+  }],
+  "included": [{
+    "type": "people",
+    "id": "9",
+    "attributes": {
+      "first-name": "Dan",
+      "last-name": "Gebhardt",
+      "twitter": "dgeb"
+    },
+    "links": {
+      "self": "http://example.com/people/9"
+    }
+  }]
+}

--- a/src/test/resources/users.json
+++ b/src/test/resources/users.json
@@ -5,6 +5,9 @@
       "id": "1",
       "attributes": {
         "name": "liz"
+      },
+      "relationships": {
+        "statuses": {}
       }
     },
     {
@@ -12,6 +15,9 @@
       "id": "2",
       "attributes": {
         "name": "john"
+      },
+      "relationships": {
+        "statuses": {}
       }
     }
   ]


### PR DESCRIPTION
This purpose of this PR is to allow to have all the relationships of a resource object to be always present inside relationships node and have links if they exists for a relationship.

As per the json api spec ->

A “relationship object” MUST contain at least one of the following:
  - links: a links object containing at least one of the following:
    - self: a link for the relationship itself (a “relationship link”). This link allows the client to directly manipulate the relationship. For example, removing an author through an article’s relationship URL would disconnect the person from the article without deleting the people resource itself. When fetched successfully, this link returns the linkage for the related resources as its primary data. (See Fetching Relationships.)
    - related: a related resource link
  - data: resource linkage
  - meta: a meta object that contains non-standard meta-information about the relationship.
  
Since above we have allowed all the relationships node to be always present, hence one should also provide a way to have atleast one to be always present out of the (data, meta and links)
 
The soul need for the above change is to make the client to be aware of all the relationships associated with the resource objects.