### PR TITLE
Option to throw an exception on unknown relationships

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/DeserializationFeature.java
+++ b/src/main/java/com/github/jasminb/jsonapi/DeserializationFeature.java
@@ -3,6 +3,8 @@ package com.github.jasminb.jsonapi;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.github.jasminb.jsonapi.exceptions.UnknownRelationshipException;
+
 /**
  * Enumeration that defines list of deserialization features that can be set to {@link ResourceConverter}.
  *
@@ -25,7 +27,13 @@ public enum DeserializationFeature {
 	 * This option determines if relationship (collection) can have unknown type.
 	 * Can be use with polymorphic relationship.
 	 */
-	ALLOW_UNKNOWN_TYPE_IN_RELATIONSHIP(false);
+	ALLOW_UNKNOWN_TYPE_IN_RELATIONSHIP(false),
+
+	/**
+	 * This option determines whether encountering undeclared relationships throws
+	 * an {@link UnknownRelationshipException} during conversion
+	 */
+	ALLOW_UNKNOWN_RELATIONSHIPS(false);
 
 	private final boolean enabledByDefault;
 

--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
 import com.github.jasminb.jsonapi.exceptions.DocumentSerializationException;
+import com.github.jasminb.jsonapi.exceptions.UnknownRelationshipException;
 import com.github.jasminb.jsonapi.exceptions.UnregisteredTypeException;
 import com.github.jasminb.jsonapi.models.errors.Error;
 
@@ -543,6 +544,9 @@ public class ResourceConverter {
 							}
 						}
 					}
+				} else if (!deserializationFeatures.contains(DeserializationFeature.ALLOW_UNKNOWN_RELATIONSHIPS)) {
+					throw new UnknownRelationshipException(
+							"Trying to parse unknown relationship '" + field + "' in " + object.getClass());
 				}
 			}
 		}

--- a/src/main/java/com/github/jasminb/jsonapi/exceptions/UnknownRelationshipException.java
+++ b/src/main/java/com/github/jasminb/jsonapi/exceptions/UnknownRelationshipException.java
@@ -1,0 +1,12 @@
+package com.github.jasminb.jsonapi.exceptions;
+
+public class UnknownRelationshipException extends RuntimeException {
+
+	public UnknownRelationshipException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public UnknownRelationshipException(String message) {
+		super(message);
+	}
+}

--- a/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/ResourceConverterTest.java
@@ -546,6 +546,7 @@ public class ResourceConverterTest {
 	@Test
 	public void testEnableAllowUnknownInclusionsTwo() throws IOException {
 		converter.enableDeserializationOption(DeserializationFeature.ALLOW_UNKNOWN_INCLUSIONS);
+		converter.enableDeserializationOption(DeserializationFeature.ALLOW_UNKNOWN_RELATIONSHIPS);
 
 		InputStream rawData = IOUtils.getResource("included_fail.json");
 		converter.readDocument(rawData, City.class).get();


### PR DESCRIPTION
While `ALLOW_UNKNOWN_INCLUSIONS` will throw on unknown types, it will not throw on undeclared relationships whose type is known. The `ALLOW_UNKNOWN_RELATIONSHIPS` feature allows such a check.