### PR TITLE
Fix for #274 (Double inclusion)

### DIFF
--- a/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
+++ b/src/main/java/com/github/jasminb/jsonapi/ResourceConverter.java
@@ -849,6 +849,13 @@ public class ResourceConverter {
 				results.add(getDataNode(object, includedDataMap, serializationSettings));
 			}
 
+			// It is possible that relationships point back to top-level resource, in this case remove it from
+			// included section since it is already present (as a top level resource)
+			for (Object object : documentCollection.get()) {
+				String identifier = String.valueOf(getIdValue(object)).concat(configuration.getTypeName(object.getClass()));
+				includedDataMap.remove(identifier);
+			}
+
 			ObjectNode result = objectMapper.createObjectNode();
 			result.set(DATA, results);
 

--- a/src/test/java/com/github/jasminb/jsonapi/SerializationTest.java
+++ b/src/test/java/com/github/jasminb/jsonapi/SerializationTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.github.jasminb.jsonapi.exceptions.DocumentSerializationException;
 import com.github.jasminb.jsonapi.models.Article;
 import com.github.jasminb.jsonapi.models.Author;
+import com.github.jasminb.jsonapi.models.Document;
 import com.github.jasminb.jsonapi.models.SimpleMeta;
 import com.github.jasminb.jsonapi.models.Status;
 import com.github.jasminb.jsonapi.models.User;
@@ -14,9 +15,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Testing functionality of JSON API converter's serialization methods..
@@ -28,7 +32,7 @@ public class SerializationTest {
 
 	@Before
 	public void setup() {
-		converter = new ResourceConverter(Status.class, User.class, Article.class, Author.class);
+		converter = new ResourceConverter(Status.class, User.class, Article.class, Author.class, Document.class);
 		converter.enableSerializationOption(SerializationFeature.INCLUDE_RELATIONSHIP_ATTRIBUTES);
 	}
 
@@ -301,6 +305,29 @@ public class SerializationTest {
 						new SerializationSettings.Builder().serializeJSONAPIObject(false).build());
 
 		Assert.assertFalse(new String(serialized).contains("\"jsonapi\":{\"version\":\"1.1\"}"));
+	}
+
+	@Test
+	public void testDoubleInclusion() throws DocumentSerializationException {
+		// A compound document MUST NOT include more than one resource object for each type and id pair.
+		Document documentA = new Document(UUID.randomUUID(), "Document A", null);
+		Document documentB = new Document(UUID.randomUUID(), "Document B", documentA);
+
+		JSONAPIDocument<List<Document>> jsonapiDocument = new JSONAPIDocument<>(Arrays.asList(documentA, documentB));
+		byte[] serialized = converter.writeDocumentCollection(jsonapiDocument);
+
+		Assert.assertTrue(new String(serialized).contains("\"included\":[]"));
+
+		JSONAPIDocument<List<Document>> deserialized = converter.readDocumentCollection(serialized, Document.class);
+
+		Assert.assertEquals(2, deserialized.get().size());
+
+		Document first = deserialized.get().get(0);
+		Document second = deserialized.get().get(1);
+
+		// Make sure the second document is the same reference as the first
+		Assert.assertTrue(first == second.getRelatedDocument());
+
 	}
 
 	private JSONAPIDocument<User> createDocument(User user) {

--- a/src/test/java/com/github/jasminb/jsonapi/models/Document.java
+++ b/src/test/java/com/github/jasminb/jsonapi/models/Document.java
@@ -1,0 +1,39 @@
+package com.github.jasminb.jsonapi.models;
+
+import com.github.jasminb.jsonapi.annotations.Id;
+import com.github.jasminb.jsonapi.annotations.Relationship;
+import com.github.jasminb.jsonapi.annotations.Type;
+
+import java.util.UUID;
+
+@Type("documents")
+public class Document {
+	@Id
+	private String id;
+
+	@Relationship("relatedDocument")
+	private Document relatedDocument;
+
+	private String title;
+
+	public Document() {
+	}
+
+	public Document(UUID id, String title, Document relatedDocument) {
+		this.id = id.toString();
+		this.title = title;
+		this.relatedDocument = relatedDocument;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public Document getRelatedDocument() {
+		return relatedDocument;
+	}
+}


### PR DESCRIPTION
With the fix, serialized data looks like following:

```json

{
    "data":
    [
        {
            "type": "documents",
            "id": "f2098c38-7eb2-4aa6-92ae-7165429afa50",
            "attributes":
            {
                "title": "Document A"
            }
        },
        {
            "type": "documents",
            "id": "4ea3653b-1c3b-4107-892c-631558aabc53",
            "attributes":
            {
                "title": "Document B"
            },
            "relationships":
            {
                "relatedDocument":
                {
                    "data":
                    {
                        "type": "documents",
                        "id": "f2098c38-7eb2-4aa6-92ae-7165429afa50"
                    }
                }
            }
        }
    ],
    "included":
    []
}
```